### PR TITLE
refactor gh action to pub docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-
 jobs:
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
TL;DR
Replace the 3rd party pages deployment with the native GitHub one.

Details
The pages are building and publishing to the gh-pages branch just fine. They just are not *deploying*.

This text on the settings/pages shows that the last deployment was still the (undesired) "pages build and deployment" instead of the custom action:

"""
Your site was last deployed to the [github-pages](https://github.com/google/mcp-security/deployments?environment=github-pages#activity-log) environment by the [pages build and deployment](https://github.com/google/mcp-security/actions/runs/14673111187) workflow.
"""