### PR TITLE
Add links to GitHub Repo

### DIFF
--- a/docs/_templates/sidebar/custom_github_link.html
+++ b/docs/_templates/sidebar/custom_github_link.html
@@ -1,0 +1,8 @@
+<div style="padding: 0.5rem 1rem 0.2rem 1rem; font-size: 0.875em;"> <!-- Mimic some padding/sizing -->
+  <a href="https://github.com/google/mcp-security" target="_blank" rel="noopener noreferrer" class="reference external">
+    <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16" style="display: inline-block; vertical-align: text-bottom; height: 1.1em; width: 1.1em; margin-right: 0.3em;">
+        <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"></path>
+    </svg>
+    GitHub Repository
+  </a>
+</div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,6 +113,15 @@ os.makedirs(static_dir, exist_ok=True)
 # Set static paths for custom CSS/JS/images
 html_static_path = ["_static", "img"]
 
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/custom_github_link.html",
+        "sidebar/search.html",
+        "sidebar/navigation.html",
+    ]
+}
+
 # Theme options
 html_theme_options = {
     "light_css_variables": {

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,6 @@ These servers allow security professionals to leverage AI assistants for securit
 
 ## Navigation
 
-👉 Use the navigation menu on the left to explore the documentation.
-
 If you're new to this project, we recommend starting with the [Usage Guide](usage_guide.md) to learn how to set up and configure the MCP servers.
 
 ## Quick Links
@@ -25,6 +23,7 @@ If you're new to this project, we recommend starting with the [Usage Guide](usag
 - **[Configuration Reference](usage_guide.md#mcp-server-configuration-reference)** - Configure the MCP servers for your environment
 - **[Usage Examples](usage_guide.md#usage-examples)** - See examples of how to interact with the MCP servers
 - **[Development Guide](development_guide.md)** - Learn how to contribute to or extend the project
+- **[GitHub Repository](https://github.com/google/mcp-security)** - Access the project's source code and contribute.
 
 ## MCP Servers
 


### PR DESCRIPTION
Adds a link on the front page and in the sidebar, so there is a link from every page

#66 #close

<img width="1072" alt="Screenshot 2025-05-20 at 1 09 03 PM" src="https://github.com/user-attachments/assets/5ae48a84-ad51-419f-bffc-a19694b59313" />
