### PR TITLE
Restricting the ADK version to 0.5.0 due to breaking changes in 1.0.0

### DIFF
--- a/run-with-google-adk/requirements.txt
+++ b/run-with-google-adk/requirements.txt
@@ -1,2 +1,2 @@
-google-adk
+google-adk==0.5.0
 uv


### PR DESCRIPTION
ADK 1.0.0 introduced breaking changes. Restricting the ADK version to 0.5.0. We are fixing the issues in the branch `google-adk-02` already but it will take some time. Meanwhile with this change the ADK agent can be used as before.