### PR TITLE
feat: Add `descriptors_only` param to relationship tools

### DIFF
--- a/server/gti/gti_mcp/tools/collections.py
+++ b/server/gti/gti_mcp/tools/collections.py
@@ -78,32 +78,33 @@ async def get_collection_report(id: str, ctx: Context) -> typing.Dict[str, typin
 
 @server.tool()
 async def get_entities_related_to_a_collection(
-    id: str, relationship_name: str, ctx: Context
+    id: str, relationship_name: str, descriptors_only: bool, ctx: Context
 ) -> typing.Dict[str, typing.Any]:
   """Retrieve entities related to the the given collection ID.
 
     The following table shows a summary of available relationships for collection objects.
 
-    | Relationship         | Return object type                                |
-    | :------------------- | :------------------------------------------------ |
-    | associations         | List of associated threats                        |
-    | attack_techniques    | List of attack techniques                         |
-    | domains              | List of Domains                                   |
-    | files                | List of Files                                     |
-    | ip_addresses         | List of IP addresses                              |
-    | urls                 | List of URLs                                      |
-    | threat_actors        | List of related threat actors                     |
-    | malware_families     | List of related malware families                  |
-    | software_toolkits    | List of related tools                             |
-    | campaigns            | List of related campaigns                         |
-    | vulnerabilities      | List of related vulnerabilities                   |
-    | reports              | List of reports                                   |
-    | suspected_threat_actors | List of related suspected threat actors        |
-    | hunting_rulesets     | Google Threat Intelligence Yara rules that identify the given collection |
+    | Relationship         | Description                                       | Return type  |
+    | -------------------- | ------------------------------------------------- | ------------ |
+    | associations         | List of associated threats                        | collection   |
+    | attack_techniques    | List of attack techniques                         | attack_technique |
+    | domains              | List of Domains                                   | domain       |
+    | files                | List of Files                                     | file         |
+    | ip_addresses         | List of IP addresses                              | ip_address   |
+    | urls                 | List of URLs                                      | url          |
+    | threat_actors        | List of related threat actors                     | collection   |
+    | malware_families     | List of related malware families                  | collection   |
+    | software_toolkits    | List of related tools                             | collection   |
+    | campaigns            | List of related campaigns                         | collection   |
+    | vulnerabilities      | List of related vulnerabilities                   | collection   |
+    | reports              | List of reports                                   | collection   |
+    | suspected_threat_actors | List of related suspected threat actors        | collection   |
+    | hunting_rulesets     | Google Threat Intelligence Yara rules that identify the given collection | hunting_ruleset |
 
     Args:
       id (required): Collection identifier.
       relationship_name (required): Relationship name.
+      descriptors_only (required): Bool. Must be True when the target object type is one of file, domain, url, ip_address or collection.
     Returns:
       List of objects related to the collection.
   """
@@ -114,7 +115,11 @@ async def get_entities_related_to_a_collection(
       }
 
   res = await utils.fetch_object_relationships(
-      vt_client(ctx), "collections", id, [relationship_name])
+      vt_client(ctx), 
+      "collections", 
+      id, 
+      [relationship_name],
+      descriptors_only=descriptors_only)
   return utils.sanitize_response(res.get(relationship_name, []))
 
 

--- a/server/gti/gti_mcp/tools/files.py
+++ b/server/gti/gti_mcp/tools/files.py
@@ -105,65 +105,66 @@ async def get_file_report(hash: str, ctx: Context) -> typing.Dict[str, typing.An
 
 @server.tool()
 async def get_entities_related_to_a_file(
-    hash: str, relationship_name: str, ctx: Context
+    hash: str, relationship_name: str, descriptors_only: bool, ctx: Context,
 ) -> typing.Dict[str, typing.Any]:
     """Retrieve entities related to the the given file hash.
 
     The following table shows a summary of available relationships for file objects.
 
-    | Relationship           | Description                                                                       |
-    | :--------------------- | :-------------------------------------------------------------------------------- |
-    | analyses               | Analyses for the file                                                             |
-    | associations           | File's associated objects (reports, campaigns, IoC collections, malware families, software toolkits, vulnerabilities, threat-actors), without filtering by the associated object type.                                                                                      |
-    | behaviours             | Behaviour reports for the file.                                                   |
-    | attack_techniques      | Returns the Attack Techniques of the File.                                        |
-    | bundled_files          | Files bundled within the file.                                                    |
-    | campaigns              | Campaigns associated to the file.                                                 |
-    | carbonblack_children   | Files derived from the file according to Carbon Black.                            |
-    | carbonblack_parents    | Files from where the file was derived according to Carbon Black.                  |
-    | collections            | IoC Collections associated to the file.                                           |
-    | comments               | Comments for the file.                                                            |
-    | compressed_parents     | Compressed files that contain the file.                                           |
-    | contacted_domains      | Domains contacted by the file.                                                    |
-    | contacted_ips          | IP addresses contacted by the file.                                               |
-    | contacted_urls         | URLs contacted by the file.                                                       |
-    | dropped_files          | Files dropped by the file during its execution.                                   |
-    | email_attachments      | Files attached to the email.                                                      |
-    | email_parents          | Email files that contained the file.                                              |
-    | embedded_domains       | Domain names embedded in the file.                                                |
-    | embedded_ips           | IP addresses embedded in the file.                                                |
-    | embedded_urls          | URLs embedded in the file.                                                        |
-    | execution_parents      | Files that executed the file.                                                     |
-    | graphs                 | Graphs that include the file.                                                     |
-    | itw_domains            | In the wild domain names from where the file has been downloaded.                 |
-    | itw_ips                | In the wild IP addresses from where the file has been downloaded.                 |
-    | itw_urls               | In the wild URLs from where the file has been downloaded.                         |
-    | malware_families       | Malware families associated to the file.                                          |
-    | memory_pattern_domains | Domain string patterns found in memory during sandbox execution.                  |
-    | memory_pattern_ips     | IP address string patterns found in memory during sandbox execution.              |
-    | memory_pattern_urls    | URL string patterns found in memory during sandbox execution.                     |
-    | overlay_children       | Files contained by the file as an overlay.                                        |
-    | overlay_parents        | File that contain the file as an overlay.                                         |
-    | pcap_children          | Files contained within the PCAP file.                                             |
-    | pcap_parents           | PCAP files that contain the file.                                                 |
-    | pe_resource_children   | Files contained by a PE file as a resource.                                       |
-    | pe_resource_parents    | PE files containing the file as a resource.                                       |
-    | related_attack_techniques    | Returns the Attack Techniques of the Collections containing this File.      |
-    | related_reports        | Reports that are directly and indirectly related to the file.                     |
-    | related_threat_actors  | File's related threat actors.                                                     |
-    | reports                | Reports directly associated to the file.                                          |
-    | screenshots            | Screenshots related to the sandbox execution of the file.                         |
-    | similar_files          | Files that are similar to the file.                                               |
-    | software_toolkits      | Software and Toolkits associated to the file.                                     |
-    | submissions            | Submissions for the file.                                                         |
-    | urls_for_embedded_js   | URLs where this (JS) file is embedded.                                            |
-    | user_votes             | File's votes made by current signed-in user.                                      |
-    | votes                  | Votes for the file.                                                               |
-    | vulnerabilities        | Vulnerabilities associated to the file.                                           |
+    | Relationship           | Description                                                                       | Return type |
+    | ---------------------- | --------------------------------------------------------------------------------- | ----------- |
+    | analyses               | Analyses for the file                                                             | analysis |
+    | associations           | File's associated objects (reports, campaigns, IoC collections, malware families, software toolkits, vulnerabilities, threat-actors), without filtering by the associated object type.                                                                                      | collection |
+    | behaviours             | Behaviour reports for the file.                                                   | file-behaviour |
+    | attack_techniques      | Returns the Attack Techniques of the File.                                        | attack_technique |
+    | bundled_files          | Files bundled within the file.                                                    | file |
+    | campaigns              | Campaigns associated to the file.                                                 | collection |
+    | carbonblack_children   | Files derived from the file according to Carbon Black.                            | file |
+    | carbonblack_parents    | Files from where the file was derived according to Carbon Black.                  | file |
+    | collections            | IoC Collections associated to the file.                                           | collection |
+    | comments               | Comments for the file.                                                            | comment |
+    | compressed_parents     | Compressed files that contain the file.                                           | file |
+    | contacted_domains      | Domains contacted by the file.                                                    | domain |
+    | contacted_ips          | IP addresses contacted by the file.                                               | ip_address |
+    | contacted_urls         | URLs contacted by the file.                                                       | url |
+    | dropped_files          | Files dropped by the file during its execution.                                   | file |
+    | email_attachments      | Files attached to the email.                                                      | file |
+    | email_parents          | Email files that contained the file.                                              | file |
+    | embedded_domains       | Domain names embedded in the file.                                                | domain |
+    | embedded_ips           | IP addresses embedded in the file.                                                | ip_address |
+    | embedded_urls          | URLs embedded in the file.                                                        | url |
+    | execution_parents      | Files that executed the file.                                                     | file |
+    | graphs                 | Graphs that include the file.                                                     | graph |
+    | itw_domains            | In the wild domain names from where the file has been downloaded.                 | domain |
+    | itw_ips                | In the wild IP addresses from where the file has been downloaded.                 | ip_address |
+    | itw_urls               | In the wild URLs from where the file has been downloaded.                         | url |
+    | malware_families       | Malware families associated to the file.                                          | collection |
+    | memory_pattern_domains | Domain string patterns found in memory during sandbox execution.                  | domain |
+    | memory_pattern_ips     | IP address string patterns found in memory during sandbox execution.              | ip_address |
+    | memory_pattern_urls    | URL string patterns found in memory during sandbox execution.                     | url |
+    | overlay_children       | Files contained by the file as an overlay.                                        | file |
+    | overlay_parents        | File that contain the file as an overlay.                                         | file |
+    | pcap_children          | Files contained within the PCAP file.                                             | file |
+    | pcap_parents           | PCAP files that contain the file.                                                 | file |
+    | pe_resource_children   | Files contained by a PE file as a resource.                                       | file |
+    | pe_resource_parents    | PE files containing the file as a resource.                                       | file |
+    | related_attack_techniques    | Returns the Attack Techniques of the Collections containing this File.      | attack_technique |
+    | related_reports        | Reports that are directly and indirectly related to the file.                     | collection |
+    | related_threat_actors  | File's related threat actors.                                                     | collection |
+    | reports                | Reports directly associated to the file.                                          | collection |
+    | screenshots            | Screenshots related to the sandbox execution of the file.                         | screenshot |
+    | similar_files          | Files that are similar to the file.                                               | file |
+    | software_toolkits      | Software and Toolkits associated to the file.                                     | collection |
+    | submissions            | Submissions for the file.                                                         | submission |
+    | urls_for_embedded_js   | URLs where this (JS) file is embedded.                                            | url |
+    | user_votes             | File's votes made by current signed-in user.                                      | vote |
+    | votes                  | Votes for the file.                                                               | vote |
+    | vulnerabilities        | Vulnerabilities associated to the file.                                           | collection |
 
     Args:
       hash (required): MD5/SHA1/SHA256) hash that identifies the file.
       relationship_name (required): Relationship name.
+      descriptors_only (required): Bool. Must be True when the target object type is one of file, domain, url, ip_address or collection.
     Returns:
       List of objects related to the given file.
     """
@@ -174,7 +175,11 @@ async def get_entities_related_to_a_file(
         }
 
     res = await utils.fetch_object_relationships(
-        vt_client(ctx), "files", hash, [relationship_name])
+        vt_client(ctx), 
+        "files",
+        hash, 
+        relationships=[relationship_name],
+        descriptors_only=descriptors_only)
     return utils.sanitize_response(res.get(relationship_name, []))
 
 

--- a/server/gti/gti_mcp/tools/netloc.py
+++ b/server/gti/gti_mcp/tools/netloc.py
@@ -108,47 +108,51 @@ async def get_domain_report(domain: str, ctx: Context) -> typing.Dict[str, typin
 
 
 @server.tool()
-async def get_entities_related_to_a_domain(domain: str, relationship_name: str, ctx: Context) -> typing.Dict[str, typing.Any]:
+async def get_entities_related_to_a_domain(
+    domain: str, relationship_name: str, descriptors_only: bool, ctx: Context
+) -> typing.Dict[str, typing.Any]:
   """Retrieve entities related to the the given domain.
 
     The following table shows a summary of available relationships for domain objects.
 
-    | Relationship                | Description                                                |
-    | :-------------------------- | :--------------------------------------------------------- |
-    | associations                | Domain's associated objects (reports, campaigns, IoC collections, malware families, software toolkits, vulnerabilities, threat-actors), without filtering by the associated object type.                                                             | Everyone. | List of [reports](ref:report-object), [campaigns](ref:campaign-object), [IoC collections](ref:ioc-collection-object), [malware families](ref:malware-family-object), [software toolkits](ref:software-toolkit-object), [vulnerabilities](ref:vulnerability-object), [threat-actors](ref:threat-actor-object) objecs.|
-    | caa_records                 | Records CAA for the domain.                                |
-    | campaigns                   | Campaigns associated to the domain.                        |
-    | cname_records               | Records CNAME for the domain.                              |
-    | collections                 | IoC Collections associated to the domain.                  |
-    | comments                    | Community posted comments about the domain.                |
-    | communicating_files         | Files that communicate with the domain.                    |
-    | downloaded_files            | Files downloaded from that domain.                         |
-    | graphs                      | Graphs including the domain.                               |
-    | historical_ssl_certificates | SSL certificates associated with the domain.               |
-    | historical_whois            | WHOIS information for the domain.                          |
-    | immediate_parent            | Domain's immediate parent.                                 |
-    | malware_families            | Malware families associated to the domain.                 |
-    | memory_pattern_parents      | Files having a domain as string on memory during sandbox execution.  |
-    | mx_records                  | Records MX for the domain.                                 |
-    | ns_records                  | Records NS for the domain.                                 |
-    | parent                      | Domain's top parent.                                       |
-    | referrer_files              | Files containing the domain.                               |
-    | related_comments            | Community posted comments in the domain's related objects. |
-    | related_reports             | Reports that are directly and indirectly related to the domain. |
-    | related_threat_actors       | Threat actors related to the domain.                       |
-    | reports                     | Reports directly associated to the domain.                 |
-    | resolutions                 | DNS resolutions for the domain.                            |
-    | siblings                    | Domain's sibling domains.                                  |
-    | soa_records                 | Records SOA for the domain.                                |
-    | software_toolkits           | Software and Toolkits associated to the domain.            |
-    | subdomains                  | Domain's subdomains.                                       |
-    | urls                        | URLs having this domain.                                   |
-    | user_votes                  | Current user's votes.                                      |
-    | votes                       | Domain's votes.                                            |
-    | vulnerabilities             | Vulnerabilities associated to the domain.                  |
+    | Relationship                | Description                                                | Return type  |
+    | --------------------------- | ---------------------------------------------------------- | ------------ |
+    | associations                | Domain's associated objects (reports, campaigns, IoC collections, malware families, software toolkits, vulnerabilities, threat-actors), without filtering by the associated object type.                                                             | Everyone. | List of [reports](ref:report-object), [campaigns](ref:campaign-object), [IoC collections](ref:ioc-collection-object), [malware families](ref:malware-family-object), [software toolkits](ref:software-toolkit-object), [vulnerabilities](ref:vulnerability-object), [threat-actors](ref:threat-actor-object) objecs.| collection |
+    | caa_records                 | Records CAA for the domain.                                | domain       |
+    | campaigns                   | Campaigns associated to the domain.                        | collection   |
+    | cname_records               | Records CNAME for the domain.                              | domain       |
+    | collections                 | IoC Collections associated to the domain.                  | collection   |
+    | comments                    | Community posted comments about the domain.                | comment      |
+    | communicating_files         | Files that communicate with the domain.                    | file         |
+    | downloaded_files            | Files downloaded from that domain.                         | file         |
+    | graphs                      | Graphs including the domain.                               | graph        |
+    | historical_ssl_certificates | SSL certificates associated with the domain.               | ssl-cert     |
+    | historical_whois            | WHOIS information for the domain.                          | whois        |
+    | immediate_parent            | Domain's immediate parent.                                 | domain       |
+    | malware_families            | Malware families associated to the domain.                 | collection   |
+    | memory_pattern_parents      | Files having a domain as string on memory during sandbox execution. | file |
+    | mx_records                  | Records MX for the domain.                                 | domain       |
+    | ns_records                  | Records NS for the domain.                                 | domain       |
+    | parent                      | Domain's top parent.                                       | domain       |
+    | referrer_files              | Files containing the domain.                               | file         |
+    | related_comments            | Community posted comments in the domain's related objects. | comment      |
+    | related_reports             | Reports that are directly and indirectly related to the domain. | collection |
+    | related_threat_actors       | Threat actors related to the domain.                       | collection   |
+    | reports                     | Reports directly associated to the domain.                 | collection   |
+    | resolutions                 | DNS resolutions for the domain.                            | resolution   |
+    | siblings                    | Domain's sibling domains.                                  | domain       |
+    | soa_records                 | Records SOA for the domain.                                | domain       |
+    | software_toolkits           | Software and Toolkits associated to the domain.            | collection   |
+    | subdomains                  | Domain's subdomains.                                       | domain       |
+    | urls                        | URLs having this domain.                                   | url          |
+    | user_votes                  | Current user's votes.                                      | vote         |
+    | votes                       | Domain's votes.                                            | vote         |
+    | vulnerabilities             | Vulnerabilities associated to the domain.                  | collection   |
 
     Args:
       domain (required): Domain to analyse.
+      relationship_name (required): Relationship name.
+      descriptors_only (required): Bool. Must be True when the target object type is one of file, domain, url, ip_address or collection.
     Returns:
       List of entities related to the domain.
   """
@@ -159,7 +163,10 @@ async def get_entities_related_to_a_domain(domain: str, relationship_name: str, 
     }
 
   res = await utils.fetch_object_relationships(
-      vt_client(ctx), "domains", domain, [relationship_name])
+      vt_client(ctx), 
+      "domains", domain, 
+      relationships=[relationship_name],
+      descriptors_only=descriptors_only)
   return utils.sanitize_response(res.get(relationship_name, []))
 
 
@@ -182,38 +189,42 @@ async def get_ip_address_report(ip_address: str, ctx: Context) -> typing.Dict[st
 
 
 @server.tool()
-async def get_entities_related_to_an_ip_address(ip_address: str, relationship_name: str, ctx: Context) -> typing.Dict[str, typing.Any]:
+async def get_entities_related_to_an_ip_address(
+    ip_address: str, relationship_name: str, descriptors_only: bool, ctx: Context
+) -> typing.Dict[str, typing.Any]:
   """Retrieve entities related to the the given IP Address.
 
     The following table shows a summary of available relationships for IP Address objects.
 
-    | Relationship                | Description                                            |
-    | :-------------------------- | :----------------------------------------------------- |
-    | associations                | IP's associated objects (reports, campaigns, IoC collections, malware families, software toolkits, vulnerabilities, threat-actors), without filtering by the associated object type.                                               |
-    | campaigns                   | Campaigns associated to the IP address.                |
-    | collections                 | IoC Collections associated to the IP address.          |
-    | comments                    | Comments for the IP address.                           |
-    | communicating_files         | Files that communicate with the IP address.            |
-    | downloaded_files            | Files downloaded from the IP address.                  |
-    | graphs                      | Graphs including the IP address.                       |
-    | historical_ssl_certificates | SSL certificates associated with the IP.               |
-    | historical_whois            | WHOIS information for the IP address.                  |
-    | malware_families            | Malware families associated to the IP address.         |
-    | memory_pattern_parents      | Files having an IP as string on memory during sandbox execution.         |
-    | referrer_files              | Files containing the IP address.                       |
-    | related_comments            | Community posted comments in the IP's related objects. |
-    | related_reports             | Reports that are directly and indirectly related to the IP. |
-    | related_threat_actors       | Threat actors related to the IP address.               |
-    | reports                     | Reports directly associated to the IP.                 |
-    | resolutions                 | IP address' resolutions                                |
-    | software_toolkits           | Software and Toolkits associated to the IP address.    |
-    | urls                        | URLs related to the IP address.                        |
-    | user_votes                  | IP's votes made by current signed-in user.             |
-    | votes                       | IP's votes.                                            |
-    | vulnerabilities             | Vulnerabilities associated to the IP address.          |
+    | Relationship                | Description                                            | Return type  |
+    | --------------------------- | ------------------------------------------------------ | ------------ |
+    | associations                | IP's associated objects (reports, campaigns, IoC collections, malware families, software toolkits, vulnerabilities, threat-actors), without filtering by the associated object type. | collection |
+    | campaigns                   | Campaigns associated to the IP address.                | collection   |
+    | collections                 | IoC Collections associated to the IP address.          | collection   |
+    | comments                    | Comments for the IP address.                           | comment      |
+    | communicating_files         | Files that communicate with the IP address.            | file         |
+    | downloaded_files            | Files downloaded from the IP address.                  | file         |
+    | graphs                      | Graphs including the IP address.                       | graph        |
+    | historical_ssl_certificates | SSL certificates associated with the IP.               | ssl-cert     |
+    | historical_whois            | WHOIS information for the IP address.                  | whois        |
+    | malware_families            | Malware families associated to the IP address.         | collection   |
+    | memory_pattern_parents      | Files having an IP as string on memory during sandbox execution. | file |
+    | referrer_files              | Files containing the IP address.                       | file         |
+    | related_comments            | Community posted comments in the IP's related objects. | comment      |
+    | related_reports             | Reports that are directly and indirectly related to the IP. | collection |
+    | related_threat_actors       | Threat actors related to the IP address.               | collection   |
+    | reports                     | Reports directly associated to the IP.                 | collection   |
+    | resolutions                 | IP address' resolutions                                | resolution   |
+    | software_toolkits           | Software and Toolkits associated to the IP address.    | collection   |
+    | urls                        | URLs related to the IP address.                        | url          |
+    | user_votes                  | IP's votes made by current signed-in user.             | vote         |
+    | votes                       | IP's votes.                                            | vote         |
+    | vulnerabilities             | Vulnerabilities associated to the IP address.          | collection   |
 
     Args:
       ip_address (required): IP Addres to analyse.
+      relationship_name (required): Relationship name.
+      descriptors_only (required): Bool. Must be True when the target object type is one of file, domain, url, ip_address or collection.
     Returns:
       List of entities related to the IP Address.
   """
@@ -224,5 +235,9 @@ async def get_entities_related_to_an_ip_address(ip_address: str, relationship_na
     }
 
   res = await utils.fetch_object_relationships(
-      vt_client(ctx), "ip_addresses", ip_address, [relationship_name])
+      vt_client(ctx), 
+      "ip_addresses",
+      ip_address,
+      relationships=[relationship_name],
+      descriptors_only=descriptors_only)
   return utils.sanitize_response(res.get(relationship_name, []))

--- a/server/gti/gti_mcp/tools/urls.py
+++ b/server/gti/gti_mcp/tools/urls.py
@@ -90,48 +90,52 @@ async def get_url_report(url: str, ctx: Context) -> typing.Dict[str, typing.Any]
 
 
 @server.tool()
-async def get_entities_related_to_an_url(url: str, relationship_name: str, ctx: Context) -> typing.Dict[str, typing.Any]:
+async def get_entities_related_to_an_url(
+    url: str, relationship_name: str, descriptors_only: bool, ctx: Context
+) -> typing.Dict[str, typing.Any]:
   """Retrieve entities related to the the given URL.
 
     The following table shows a summary of available relationships for URL objects.
 
-    | Relationship            | Description                                                    |
-    | :---------------------- | :------------------------------------------------------------- |
-    | analyses                | Analyses for the URL.                                          |
-    | associations            | URL's associated objects (reports, campaigns, IoC collections, malware families, software toolkits, vulnerabilities, threat-actors), without filtering by the associated object type. |
-    | campaigns               | Campaigns associated to the URL.                               |
-    | collections             | IoC Collections associated to the URL.                         |
-    | comments                | Community posted comments about the URL.                       |
-    | communicating_files     | Files that communicate with a given URL when they're executed. |
-    | contacted_domains       | Domains from which the URL loads some kind of resource.        |
-    | contacted_ips           | IPs from which the URL loads some kind of resource.            |
-    | downloaded_files        | Files downloaded from the URL.                                 |
-    | embedded_js_files       | JS files embedded in a URL.                                    |
-    | graphs                  | Graphs including the URL.                                      |
-    | http_response_contents                  | TTP response contents from the URL.            |
-    | last_serving_ip_address | Last IP address that served the URL.                           |
-    | malware_families        | Malware families associated to the URL.                        |
-    | memory_pattern_parents        | Files having a domain as string on memory during sandbox execution.                                |
-    | network_location        | Domain or IP for the URL.                                      |
-    | parent_resource_urls           | Returns the URLs where this URL has been loaded as resource.                                        |
-    | redirecting_urls           | URLs that redirected to the given URL.                      |
-    | redirects_to           | URLs that this url redirects to.                                |
-    | referrer_files          | Files containing the URL.                                      |
-    | referrer_urls           | URLs referring the URL.                                        |
-    | related_collections        | Returns the Collections of the parent Domains or IPs of this URL.        |
-    | related_comments        | Community posted comments in the URL's related objects.        |
-    | related_reports    | Reports that are directly and indirectly related to the URL.        |
-    | related_threat_actors    | URL's related threat actors.                                  |
-    | reports                 | Reports directly associated to the URL.                        |
-    | software_toolkits       | Software and Toolkits associated to the URL.                   |
-    | submissions             | URL's submissions.                                             |
-    | urls_related_by_tracker_id           | URLs that share the same tracker ID.              |
-    | user_votes          | URL's votes made by current signed-in user.                        |
-    | votes                  | Votes for the URL.                                              |
-    | vulnerabilities        | Vulnerabilities associated to the URL.                          |
+    | Relationship            | Description                                                    | Return type  |
+    | ----------------------- | -------------------------------------------------------------- | ------------ | 
+    | analyses                | Analyses for the URL.                                          | analyse      |
+    | associations            | URL's associated objects (reports, campaigns, IoC collections, malware families, software toolkits, vulnerabilities, threat-actors), without filtering by the associated object type. | collection |
+    | campaigns               | Campaigns associated to the URL.                               | collection   |
+    | collections             | IoC Collections associated to the URL.                         | collection   |
+    | comments                | Community posted comments about the URL.                       | comment      |
+    | communicating_files     | Files that communicate with a given URL when they're executed. | file         |
+    | contacted_domains       | Domains from which the URL loads some kind of resource.        | domain       |
+    | contacted_ips           | IPs from which the URL loads some kind of resource.            | ip_address   |
+    | downloaded_files        | Files downloaded from the URL.                                 | file         |
+    | embedded_js_files       | JS files embedded in a URL.                                    | file         |
+    | graphs                  | Graphs including the URL.                                      | graph        |
+    | http_response_contents  | HTTP response contents from the URL.                           | file         |
+    | last_serving_ip_address | Last IP address that served the URL.                           | ip_address   |
+    | malware_families        | Malware families associated to the URL.                        | collection   |
+    | memory_pattern_parents  | Files having a domain as string on memory during sandbox execution. | file    |
+    | network_location        | Domain or IP for the URL.                                      | domain or ip_address |
+    | parent_resource_urls    | Returns the URLs where this URL has been loaded as resource.   | url          |
+    | redirecting_urls        | URLs that redirected to the given URL.                         | url          |
+    | redirects_to            | URLs that this url redirects to.                               | url          |
+    | referrer_files          | Files containing the URL.                                      | file         |
+    | referrer_urls           | URLs referring the URL.                                        | url          |
+    | related_collections     | Returns the Collections of the parent Domains or IPs of this URL. | collection  |
+    | related_comments        | Community posted comments in the URL's related objects.        | comment      |
+    | related_reports         | Reports that are directly and indirectly related to the URL.   | collection   |
+    | related_threat_actors   | URL's related threat actors.                                   | collection   |
+    | reports                 | Reports directly associated to the URL.                        | collection   |
+    | software_toolkits       | Software and Toolkits associated to the URL.                   | collection   |
+    | submissions             | URL's submissions.                                             | url          |
+    | urls_related_by_tracker_id | URLs that share the same tracker ID.                        | url          |
+    | user_votes          | URL's votes made by current signed-in user.                        | vote         |
+    | votes                  | Votes for the URL.                                              | vote         |
+    | vulnerabilities        | Vulnerabilities associated to the URL.                          | collection   |
 
     Args:
       url (required): URL to analyse.
+      relationship_name (required): Relationship name.
+      descriptors_only (required): Bool. Must be True when the target object type is one of file, domain, url, ip_address or collection.
     Returns:
       List of entities related to the URL.
   """
@@ -143,5 +147,9 @@ async def get_entities_related_to_an_url(url: str, relationship_name: str, ctx: 
 
   url_id = url_to_base64(url)
   res = await utils.fetch_object_relationships(
-      vt_client(ctx), "urls", url_id, [relationship_name])
+      vt_client(ctx),
+      "urls", 
+      url_id,
+      relationships=[relationship_name],
+      descriptors_only=descriptors_only)
   return utils.sanitize_response(res.get(relationship_name, []))

--- a/server/gti/gti_mcp/utils.py
+++ b/server/gti/gti_mcp/utils.py
@@ -75,16 +75,19 @@ async def fetch_object_relationships(
     resource_collection_type: str,
     resource_id: str,
     relationships: typing.List[str],
-    params: dict[str, typing.Any] | None = None):
+    params: dict[str, typing.Any] | None = None,
+    descriptors_only: bool = True):
   """Fetches the given relationships descriptors from the given object."""
   rel_futures = {}
+  # If true, returns descriptors instead of full objects.
+  descriptors = '/relationship' if descriptors_only else ''
   async with asyncio.TaskGroup() as tg:
     for rel_name in relationships:
       rel_futures[rel_name] = tg.create_task(
           consume_vt_iterator(
               vt_client,
               f"/{resource_collection_type}/{resource_id}"
-              f"/relationship/{rel_name}", params=params))
+              f"{descriptors}/{rel_name}", params=params))
 
   data = {}
   for name, items in rel_futures.items():


### PR DESCRIPTION
Fixes https://github.com/google/mcp-security/issues/68

This commit introduces a `descriptors_only` parameter to the `get_entities_related_to_a_*` tools. This parameter allows users to retrieve only the descriptors of related entities, which can improve performance and reduce the amount of data transferred.

The `descriptors_only` parameter is required when the target object type is one of file, domain, url, ip_address or collection.