### PR TITLE
minor docs updates to better support OSX users

### DIFF
--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -76,6 +76,11 @@ Once configured, you can interact with the MCP servers by asking Claude to perfo
 
 Here's a complete reference configuration for all available MCP servers. However, we strongly recommend using environment variables instead of hardcoding sensitive information like API keys:
 
+**NOTE:** For OSX users, if you used [this one-liner](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) to install uv, use the full path to the uv binary for the "command" value below, as uv will not be placed in the system path for Claude to use! For example: `/Users/yourusername/.local/bin/uv` instead of just `uv`.
+
+Additionally, for the secops-soar MCP server, you will need use the CA list bundled with the certifi package. This can be done via the following command. Change the Python minor version to match whatever version you are currently running. (ex. `Python\ 3.11`):
+`/Applications/Python\ 3.12/Install\ Certificates.command`
+
 ```json
 {
   "mcpServers": {

--- a/server/gti/README.md
+++ b/server/gti/README.md
@@ -60,6 +60,8 @@ Threat Intelligence suite.
 
 Add the following configuration to your MCP client's settings file:
 
+**NOTE:** For OSX users, if you used [this one-liner](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) to install uv, use the full path to the uv binary for the "command" value below, as uv will not be placed in the system path for Claude to use! For example: `/Users/yourusername/.local/bin/uv` instead of just `uv`.
+
 ```json
 {
   "mcpServers": {

--- a/server/scc/README.md
+++ b/server/scc/README.md
@@ -26,6 +26,8 @@ This is an MCP (Model Context Protocol) server for interacting with Google Cloud
 
 Add the following configuration to your MCP client's settings file:
 
+**NOTE:** For OSX users, if you used [this one-liner](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) to install uv, use the full path to the uv binary for the "command" value below, as uv will not be placed in the system path for Claude to use! For example: `/Users/yourusername/.local/bin/uv` instead of just `uv`.
+
 ```json
 {
   "mcpServers": {

--- a/server/secops-soar/README.md
+++ b/server/secops-soar/README.md
@@ -46,6 +46,11 @@ To use this MCP server with Claude Desktop:
 
 4.  Update your `claude_desktop_config.json` with the following configuration
     (replace paths with your actual paths):
+    
+    **NOTE:** For OSX users, if you used [this one-liner](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) to install uv, use the full path to the uv binary for the "command" value below, as uv will not be placed in the system path for Claude to use! For example: `/Users/yourusername/.local/bin/uv` instead of just `uv`.
+
+    Additionally, for the secops-soar MCP server, you will need use the CA list bundled with the certifi package. This can be done via the following command. Change the Python minor version to match whatever version you are currently running. (ex. `Python\ 3.11`):
+    `/Applications/Python\ 3.12/Install\ Certificates.command`
 
 ```json
 {

--- a/server/secops/README.md
+++ b/server/secops/README.md
@@ -50,6 +50,8 @@ See `example.py` for a complete example of using the MCP server.
 
 Add the following configuration to your MCP client's settings file:
 
+**NOTE:** For OSX users, if you used [this one-liner](https://docs.astral.sh/uv/getting-started/installation/#standalone-installer) to install uv, use the full path to the uv binary for the "command" value below, as uv will not be placed in the system path for Claude to use! For example: `/Users/yourusername/.local/bin/uv` instead of just `uv`.
+
 #### Using uv (Recommended)
 
 ```json


### PR DESCRIPTION
Added a recurring docs note for OSX users if they intend to use uv and claude specifically, as well as call out the necessary command for getting secops-soar to work (certifi certficiate "install")