### PR TITLE
mv secops_soar_mcp.py -> server.py

### DIFF
--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -106,7 +106,7 @@ Additionally, for the secops-soar MCP server, you will need use the CA list bund
         "--directory",
         "/path/to/the/repo/server/secops-soar",
         "run",
-        "secops_soar_mcp.py",
+        "server.py",
         "--integrations",
         "CSV,OKTA"
       ],


### PR DESCRIPTION
We renamed secops_soar_mcp.py to server.py but missed updating the docs.