### PR TITLE
fix docstrings

### DIFF
--- a/run-with-google-adk/utils_extensions_cbs_tools/callbacks.py
+++ b/run-with-google-adk/utils_extensions_cbs_tools/callbacks.py
@@ -87,5 +87,5 @@ def bac_setup_state_variable(callback_context: CallbackContext) -> Optional[type
       }      
       callback_context.state.update(initial_state)
     else:
-      logging.info(f"Found user_name with value {current_state["user_name"]}...")       
+      logging.info(f"Found user_name with value {current_state['user_name']}...")
     return None

--- a/run-with-google-adk/utils_extensions_cbs_tools/tools.py
+++ b/run-with-google-adk/utils_extensions_cbs_tools/tools.py
@@ -41,7 +41,7 @@ async def store_file(tool_context:ToolContext,**kwargs)->dict:
    html_file_name=file_name+".html"
    # write to the disk and then save into the artifact service
    # writing to disk is totally optional
-   with open(f"{os.environ.get("LOCAL_DIR_FOR_FILES","/tmp")}/{file_name}.html", "w", encoding="utf-8") as f:
+   with open(f"{os.environ.get('LOCAL_DIR_FOR_FILES','/tmp')}/{file_name}.html", "w", encoding="utf-8") as f:
         f.write(html_output)
 
    file_artifact = types.Part.from_bytes( # from_text is available but does not work with GCS.
@@ -121,7 +121,7 @@ def get_file_link(user_name:str,file_name:str)->dict:
     try:
         storage_client = storage.Client.from_service_account_json(os.environ.get("GCS_SA_JSON"))
         bucket_name = os.environ.get("GCS_ARTIFACT_SERVICE_BUCKET")
-        ultimate_directory = f"{os.environ.get("APP_NAME")}/{user_name}/user/{file_name}"
+        ultimate_directory = f"{os.environ.get('APP_NAME')}/{user_name}/user/{file_name}"
         # GCS stores files as versions (not GCS versions but file named 0,1,2,3 within the ultimate folder)
         blobs = storage_client.list_blobs(bucket_name, prefix=ultimate_directory)
 


### PR DESCRIPTION
Fixing exceptions in ADK like:
2025-06-25 07:58:34,259 - ERROR - fast_api.py:804 - Error in event_generator: Fail to load 'google_mcp_security_agent' module. f-string: unmatched '[' (callbacks.py, line 90)
Traceback (most recent call last):
  File "/opt/homebrew/lib/python3.11/site-packages/google/adk/cli/fast_api.py", line 792, in event_generator
    runner = await _get_runner_async(req.app_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/adk/cli/fast_api.py", line 941, in _get_runner_async
    root_agent = agent_loader.load_agent(app_name)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/adk/cli/utils/agent_loader.py", line 164, in load_agent
    agent = self._perform_load(agent_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/adk/cli/utils/agent_loader.py", line 142, in _perform_load
    if root_agent := self._load_from_module_or_package(agent_name):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/adk/cli/utils/agent_loader.py", line 81, in _load_from_module_or_package
    raise e
  File "/opt/homebrew/lib/python3.11/site-packages/google/adk/cli/utils/agent_loader.py", line 53, in _load_from_module_or_package
    module_candidate = importlib.import_module(agent_name)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.11/3.11.11/Frameworks/Python.framework/Versions/3.11/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/raybrian/playground/adk-play-1/mcp-security/run-with-google-adk/google_mcp_security_agent/__init__.py", line 14, in <module>
    from . import agent
  File "/Users/raybrian/playground/adk-play-1/mcp-security/run-with-google-adk/google_mcp_security_agent/agent.py", line 21, in <module>
    from utils_extensions_cbs_tools.callbacks import bmc_trim_llm_request, bac_setup_state_variable
  File "/Users/raybrian/playground/adk-play-1/mcp-security/run-with-google-adk/utils_extensions_cbs_tools/callbacks.py", line 90
    logging.info(f"Found user_name with value {current_state["user_name"]}...")
                                                              ^^^^^^^^^
SyntaxError: Fail to load 'google_mcp_security_agent' module. f-string: unmatched '['