### PR TITLE
Fix: Type Hint Mismatch in get_entities_related_to_a_collection

### DIFF
--- a/server/gti/gti_mcp/tools/collections.py
+++ b/server/gti/gti_mcp/tools/collections.py
@@ -85,7 +85,7 @@ async def get_collection_report(id: str, ctx: Context) -> typing.Dict[str, typin
 @server.tool()
 async def get_entities_related_to_a_collection(
     id: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10
-) -> typing.Dict[str, typing.Any]:
+) -> typing.List[typing.Dict[str, typing.Any]]:
   """Retrieve entities related to the the given collection ID.
 
     The following table shows a summary of available relationships for collection objects.


### PR DESCRIPTION
## Description:

  This pull request addresses a ValidationError encountered when calling the
  get_entities_related_to_a_collection tool. The error indicated a type mismatch between the declared return
  type of the function and its actual return value.

  Problem Description & Reproduction:


  When attempting to retrieve related entities for a file hash, specifically malware families, using the
  default_api.get_entities_related_to_a_file tool, a ValidationError was raised.

  ##  Reproduction Steps:


   1. Call the default_api.get_entities_related_to_a_file tool with the following parameters:
       * hash: "60678e352f3c849e36413f5de51b5eeca1180840c818f9ece0a0da803eb205a5"
       * relationship_name: "malware_families"
       * descriptors_only: True (or False, the error persisted with both)

![image](https://github.com/user-attachments/assets/c2130aba-476c-48b8-bac3-08f2e43479c8)


##  Observed Error:


  The tool execution resulted in a ValidationError with a message similar to:
  Error executing tool get_entities_related_to_a_file: 1 validation error for
  get_entities_related_to_a_fileOutput\nresult\n Input should be a valid dictionary [type=dict_type,
  input_value=[{'type': 'collection', ...}], input_type=list]

  This error indicated that the tool's internal validation expected a dictionary, but the
  get_entities_related_to_a_collection function (which get_entities_related_to_a_file likely calls internally or
   has a similar signature issue) was returning a list of dictionaries.

##  Solution:


  The get_entities_related_to_a_collection function in
  `mcp-security/server/gti/gti_mcp/tools/collections.py` was declared with a return type hint of
  `typing.Dict[str, typing.Any]`. However, its implementation was returning a `typing.List[typing.Dict[str,
  typing.Any]]`.

  The fix involves updating the function's type hint to accurately reflect its actual return type.

![image](https://github.com/user-attachments/assets/9be9c96a-a159-4662-966f-140e4c98b148)


##  Changes Made:


  Modified the function signature in `mcp-security/server/gti/gti_mcp/tools/collections.py` from:

```python
    async def get_entities_related_to_a_collection(
        id: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10
    ) -> typing.Dict[str, typing.Any]:
```

  to:


```python
    async def get_entities_related_to_a_collection(
        id: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10
    ) -> typing.List[typing.Dict[str, typing.Any]]:
```

  This change aligns the declared type with the actual return type, resolving the validation error.