### PR TITLE
bugfix/add missing semicolon ae_deploy_run.sh

### DIFF
--- a/run-with-google-adk/ae_deploy_run.sh
+++ b/run-with-google-adk/ae_deploy_run.sh
@@ -21,7 +21,7 @@ list_of_vars=`cat $ENV_FILE  | grep = | grep -v ^# | cut -d "=" -f1 | tr "\n" ",
 update="n"
 update_resource_name="not_available"
 
-if [[ $# -eq 1 ]] then
+if [[ $# -eq 1 ]]; then
   update="y"
   update_resource_name=$1
 fi


### PR DESCRIPTION
Line 24 of mcp-security/run-with-google-adk/ae-deploy-run.sh is missing a semicolon, leading to the script failing to run:

> if [[ $# -eq 1 ]] then
> update="y"
> update_resource_name=$1
> fi

should be

```
if [[ $# -eq 1 ]]; then
update="y"
update_resource_name=$1
fi
```

