### PR TITLE
Fix: Update mcp version and return type tools

### DIFF
--- a/server/gti/gti_mcp/tools/files.py
+++ b/server/gti/gti_mcp/tools/files.py
@@ -107,7 +107,7 @@ async def get_file_report(hash: str, ctx: Context) -> typing.Dict[str, typing.An
 @server.tool()
 async def get_entities_related_to_a_file(
     hash: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10, 
-) -> typing.Dict[str, typing.Any]:
+) -> list[dict[str, typing.Any]]:
     """Retrieve entities related to the the given file hash.
 
     The following table shows a summary of available relationships for file objects.

--- a/server/gti/gti_mcp/tools/intelligence.py
+++ b/server/gti/gti_mcp/tools/intelligence.py
@@ -104,7 +104,7 @@ async def get_hunting_ruleset(ruleset_id: str, ctx: Context) -> typing.Dict[str,
 @server.tool()
 async def get_entities_related_to_a_hunting_ruleset(
     ruleset_id: str, relationship_name: str, ctx: Context, limit: int = 10
-) -> typing.Dict[str, typing.Any]:
+) -> list[dict[str, typing.Any]]:
   """Retrieve entities related to the the given Hunting Ruleset.
 
     The following table shows a summary of available relationships for Hunting ruleset objects.

--- a/server/gti/gti_mcp/tools/netloc.py
+++ b/server/gti/gti_mcp/tools/netloc.py
@@ -111,7 +111,7 @@ async def get_domain_report(domain: str, ctx: Context) -> typing.Dict[str, typin
 @server.tool()
 async def get_entities_related_to_a_domain(
     domain: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10
-) -> typing.Dict[str, typing.Any]:
+) -> list[dict[str, typing.Any]]:
   """Retrieve entities related to the the given domain.
 
     The following table shows a summary of available relationships for domain objects.
@@ -196,7 +196,7 @@ async def get_ip_address_report(ip_address: str, ctx: Context) -> typing.Dict[st
 @server.tool()
 async def get_entities_related_to_an_ip_address(
     ip_address: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10
-) -> typing.Dict[str, typing.Any]:
+) -> list[dict[str, typing.Any]]:
   """Retrieve entities related to the the given IP Address.
 
     The following table shows a summary of available relationships for IP Address objects.

--- a/server/gti/gti_mcp/tools/urls.py
+++ b/server/gti/gti_mcp/tools/urls.py
@@ -93,7 +93,7 @@ async def get_url_report(url: str, ctx: Context) -> typing.Dict[str, typing.Any]
 @server.tool()
 async def get_entities_related_to_an_url(
     url: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10
-) -> typing.Dict[str, typing.Any]:
+) -> list[dict[str, typing.Any]]:
   """Retrieve entities related to the the given URL.
 
     The following table shows a summary of available relationships for URL objects.

--- a/server/gti/pyproject.toml
+++ b/server/gti/pyproject.toml
@@ -9,7 +9,7 @@ description = "Google Threat Intelligence MCP server"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp~=1.9.1",
+    "mcp",
     "vt-py"
 ]
 

--- a/server/gti/tests/test_tools.py
+++ b/server/gti/tests/test_tools.py
@@ -376,7 +376,7 @@ async def test_get_entities_related(
             {"hash": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f"},
             "/api/v3/files/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/behaviour_summary",
             {
-                "data": [{"type": "object", "id": "obj-id", "attributes": {"foo": "foo", "bar": ""}}],
+                "data": {"type": "object", "id": "obj-id", "attributes": {"foo": "foo", "bar": ""}},
             },
             {"type": "object", "id": "obj-id", "attributes": {"foo": "foo"}}
         ), 
@@ -394,7 +394,7 @@ async def test_get_entities_related(
             {"id": "collection_id"},
             "/api/v3/collections/collection_id/mitre_tree",
             {
-                "data": [{"type": "object", "id": "obj-id", "attributes": {"foo": "foo", "bar": ""}}],
+                "data": {"type": "object", "id": "obj-id", "attributes": {"foo": "foo", "bar": ""}},
             },
             {"type": "object", "id": "obj-id", "attributes": {"foo": "foo"}}
         ), 


### PR DESCRIPTION
- Updates the MCP dependency by removing the version pin in pyproject.toml.
- MCP version has stricter checks, changed return type of tools get_entities_related_to_* , now returning list[dict[str, typing.Any]].
