### PR TITLE
feat(gti): Add tools to create and manage collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,9 @@ app_data.db
 # Don't commit the evaluation data
 *.evalset.json
 .adk/
+
+# Gemini
+.gemini/
+
+# devcontainer
+.devcontainer/

--- a/server/gti/tests/conftest.py
+++ b/server/gti/tests/conftest.py
@@ -71,3 +71,42 @@ def fixture_vt_get_object_with_params_mock(
       query_string=vt_request_params,
   ).respond_with_json(vt_object_response)
   return make_httpserver_ipv4
+
+
+@pytest.fixture(name="vt_post_object_mock")
+def fixture_vt_post_object_mock(
+    make_httpserver_ipv4, vt_endpoint, vt_object_response, vt_request_params):
+  # Mock post object request.
+  make_httpserver_ipv4.expect_request(
+      vt_endpoint,
+      method="POST",
+      headers={"X-Apikey": "dummy_api_key"},
+      json=vt_request_params,
+  ).respond_with_json(vt_object_response)
+  return make_httpserver_ipv4
+
+
+@pytest.fixture(name="vt_patch_object_mock")
+def fixture_vt_patch_object_mock(
+    make_httpserver_ipv4, vt_endpoint, vt_object_response, vt_request_params):
+  # Mock patch object request.
+  make_httpserver_ipv4.expect_request(
+      vt_endpoint,
+      method="PATCH",
+      headers={"X-Apikey": "dummy_api_key"},
+      json=vt_request_params,
+  ).respond_with_json(vt_object_response)
+  return make_httpserver_ipv4
+
+
+@pytest.fixture(name="vt_delete_object_mock")
+def fixture_vt_delete_object_mock(
+    make_httpserver_ipv4, vt_endpoint, vt_object_response, vt_request_params):
+  # Mock delete object request.
+  make_httpserver_ipv4.expect_request(
+      vt_endpoint,
+      method="DELETE",
+      headers={"X-Apikey": "dummy_api_key"},
+      json=vt_request_params,
+  ).respond_with_json(vt_object_response, status=200)
+  return make_httpserver_ipv4


### PR DESCRIPTION
This PR introduces new tools for creating, updating attributes of, and managing IOCs within collections in Google Threat Intelligence.

### Key Changes
* **`create_collection`**: A new tool to create a collection with a name, description, and an initial set of IOCs.
* **`update_collection_attributes`**: Enables the modification of an existing collection's metadata, such as its name, description, tags, or privacy status.
* **`update_iocs_in_collection`**: Allows for adding or removing IOCs (domains, files, IP addresses, URLs) from a specified collection.
* **Testing**: Comprehensive unit tests have been added for the new tools, covering successful operations and error handling for invalid arguments.
* **.gitignore**: Updated to exclude development environment directories like `.gemini/` and `.devcontainer/`.