### PR TITLE
Upgrade secops to latest

### DIFF
--- a/server/secops/pyproject.toml
+++ b/server/secops/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "secops-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Google SecOps MCP server"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.28.1",
     "mcp[cli]>=1.4.1",
-    "secops>=0.1.17",
+    "secops>=0.8.0",
     "google-auth>=2.38.0",
     "google-auth-httplib2>=0.2.0",
     "google-api-python-client>=2.164.0"


### PR DESCRIPTION
When using the rule_text tool in secops, users report encountering: `'ChronicleClient' object has no attribute 'run_rule_test'`. That was added to the secops-wrapper library in v0.6.0, but mcp-security only requires `secops>=0.1.17`. This change forces upgrade to the latest, v0.8.0.

This change requires testing, because there could be breaking changes between 0.1.17 and 0.8.0. The test plan can look at the diff between those versions and just focus on the added/modified functions if they are found to be used in the mcp-security/server/security dir.

Longer term, we need a check to confirm new `@tool` definitions have corresponding changes in the TOML to ensure the requirements from the upstream SDK are included.