### PR TITLE
docs: remove duplicate config lines in scc_mcp.md

### DIFF
--- a/docs/servers/scc_mcp.md
+++ b/docs/servers/scc_mcp.md
@@ -35,8 +35,6 @@ Add the following configuration to your MCP client's settings file:
       "env": {},
       "disabled": false,
       "autoApprove": []
-      "disabled": false,
-      "autoApprove": []
     }
 ```
 


### PR DESCRIPTION
### Description:

Removes duplicate `disabled` and `autoApprove` lines from the JSON configuration example in `docs/servers/scc_mcp.md`.

This is a documentation-only change and has no impact on functionality.