### PR TITLE
feat(secops): add direct UDM search tool for Chronicle events

### DIFF
--- a/docs/servers/secops_mcp.md
+++ b/docs/servers/secops_mcp.md
@@ -152,6 +152,23 @@ The service account or user credentials need the following Chronicle roles:
       }
       ```
 
+- **`search_security_events_udm(udm_query, project_id=None, customer_id=None, hours_back=24, max_events=100, region=None)`**
+    - **Description:** Executes a direct Chronicle UDM query (no NL translation). Returns the same structure as the NL search for easy client reuse.
+    - **Parameters:**
+        - `udm_query` (required): UDM query string to execute.
+        - `project_id` (optional): Google Cloud project ID (defaults to environment config).
+        - `customer_id` (optional): Chronicle customer ID (defaults to environment config).
+        - `hours_back` (optional): How many hours to look back (default: 24).
+        - `max_events` (optional): Maximum number of events to return (default: 100).
+        - `region` (optional): Chronicle region (defaults to environment config or 'us').
+    - **Returns:** Dictionary containing the `udm_query` and the `events` results with `events`, `total_events`, and optional `error`.
+    - **Direct UDM Examples:**
+      - `metadata.event_type = "NETWORK_CONNECTION"`
+      - `principal.ip = "10.0.0.5" OR target.ip = "10.0.0.5"`
+      - `target.url = "http://malicious.example.com"`
+      - `lower(principal.user.userid) = "john.doe@example.com"`
+    - **When to use:** Prefer this tool when you already know the exact UDM you want to run, or when NL translation might be ambiguous. Use the NL tool to brainstorm or iterate, then switch to UDM for precise control.
+
 - **`get_security_alerts(project_id=None, customer_id=None, hours_back=24, max_alerts=10, status_filter='feedback_summary.status != "CLOSED"', region=None)`**
     - **Description:** Retrieves security alerts from Chronicle, filtered by time range and status.
     - **Parameters:**

--- a/server/secops/README.md
+++ b/server/secops/README.md
@@ -11,6 +11,9 @@ Chronicle Security Operations suite.
 - **`search_security_events(text, project_id=None, customer_id=None, hours_back=24, max_events=100, region=None)`**
     - Searches for security events in Chronicle using natural language. Translates the natural language query (`text`) into a UDM query and executes it.
 
+- **`search_security_events_udm(udm_query, project_id=None, customer_id=None, hours_back=24, max_events=100, region=None)`**
+    - Executes a direct Chronicle UDM query without natural language translation and returns results in the same structure as the NL tool.
+
 - **`get_security_alerts(project_id=None, customer_id=None, hours_back=24, max_alerts=10, status_filter='feedback_summary.status != "CLOSED"', region=None)`**
     - Retrieves security alerts from Chronicle, filtered by time range and status.
 

--- a/server/secops/example.py
+++ b/server/secops/example.py
@@ -196,6 +196,21 @@ async def security_examples(
       print(f"  Source IP: {', '.join(principal_ip)}")
       print(f"  Target IP: {', '.join(target_ip)}")
 
+  # Example 7b: Direct UDM security event search
+  print('\nExample 7b: Direct UDM security event search')
+  direct_udm = 'metadata.event_type = "USER_LOGIN"'
+  direct_events = await search_security_events_udm(
+      udm_query=direct_udm,
+      project_id=project_id,
+      customer_id=customer_id,
+      region=region,
+      hours_back=24,
+      max_events=5,
+  )
+  print(f"UDM used: {direct_events.get('udm_query')}")
+  total_direct = direct_events.get('events', {}).get('total_events', 0)
+  print(f'Found {total_direct} events for direct UDM search')
+
   # Example 7: Interactive natural language query
   print('\nExample 7: Interactive natural language query')
   try:
@@ -287,6 +302,7 @@ async def main() -> None:
 # Import the functions after defining the example functions to avoid circular imports
 from secops_mcp import (
     search_security_events,
+    search_security_events_udm,
     get_security_alerts,
     lookup_entity,
     list_security_rules,


### PR DESCRIPTION
closes: #150 
* Adds a new MCP tool search_security_events_udm to the SecOps server to execute Chronicle UDM
queries directly, bypassing natural language translation.
* Returns results in the same structure as the existing NL search tool to minimize client
changes.
* Updates docs and example to demonstrate usage; adds targeted tests.