### PR TITLE
rm erroneous str import

### DIFF
--- a/server/secops-soar/secops_soar_mcp/utils/models.py
+++ b/server/secops-soar/secops_soar_mcp/utils/models.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from enum import StrEnum
 from pydantic import BaseModel, Field
-from typing import List, Dict, str, Optional, Any
+from typing import List, Dict, Optional, Any
 
 
 class CasePriority(StrEnum):


### PR DESCRIPTION
I got a bug report on this from a backchannel. Here is some test evidence: 
> I fixed it locally (by removing `str`) and it works for me. Another [user] reported just their SOAR MCP was broken and he was doing a fresh install today. I asked him to fix that one line and [let me know] if that fixes it.