### PR TITLE
fix(gti): Correctly determine `descriptors_only` in collections tool

### DIFF
--- a/server/gti/gti_mcp/tools/collections.py
+++ b/server/gti/gti_mcp/tools/collections.py
@@ -84,7 +84,7 @@ async def get_collection_report(id: str, ctx: Context) -> typing.Dict[str, typin
 
 @server.tool()
 async def get_entities_related_to_a_collection(
-    id: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10
+    id: str, relationship_name: str, ctx: Context, limit: int = 10
 ) -> typing.List[typing.Dict[str, typing.Any]]:
   """Retrieve entities related to the the given collection ID.
 
@@ -110,7 +110,6 @@ async def get_entities_related_to_a_collection(
     Args:
       id (required): Collection identifier.
       relationship_name (required): Relationship name.
-      descriptors_only (required): Bool. Must be True when the target object type is one of file, domain, url, ip_address or collection.
       limit: Limit the number of collections to retrieve. 10 by default.
     Returns:
       List of objects related to the collection.
@@ -120,13 +119,17 @@ async def get_entities_related_to_a_collection(
           "error": f"Relationship {relationship_name} does not exist. "
           f"Available relationships are: {','.join(COLLECTION_RELATIONSHIPS)}"
       }
+  if relationship_name == "attack_techniques":
+    descriptors = False
+  else:
+    descriptors = True
   async with vt_client(ctx) as client:
     res = await utils.fetch_object_relationships(
         client, 
         "collections", 
         id, 
         [relationship_name],
-        descriptors_only=descriptors_only,
+        descriptors_only=descriptors,
         limit=limit)
   return utils.sanitize_response(res.get(relationship_name, []))
 


### PR DESCRIPTION

## Summary

This pull request addresses a bug in the `get_entities_related_to_a_collection` tool by removing the `descriptors_only` parameter and instead deriving its value from the `relationship_name`. This ensures the correct value is always used.

## File Changes

### `server/gti/gti_mcp/tools/collections.py`

- **Removed `descriptors_only` parameter**: The `descriptors_only` parameter was removed from the `get_entities_related_to_a_collection` function signature to simplify the tool's interface.
- **Dynamic `descriptors` value**: The logic now dynamically determines whether to fetch full objects or just descriptors based on the `relationship_name`. It is set to `False` for `attack_techniques` and `True` for all other relationship types.
