### PR TITLE
fix(gti): Update GTI Tool Function and Docstrings

### DIFF
--- a/server/gti/gti_mcp/tools/collections.py
+++ b/server/gti/gti_mcp/tools/collections.py
@@ -84,7 +84,7 @@ async def get_collection_report(id: str, ctx: Context) -> typing.Dict[str, typin
 
 @server.tool()
 async def get_entities_related_to_a_collection(
-    id: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10
+    id: str, relationship_name: str, ctx: Context, limit: int = 10, descriptors_only: bool = True
 ) -> typing.List[typing.Dict[str, typing.Any]]:
   """Retrieve entities related to the the given collection ID.
 
@@ -107,11 +107,15 @@ async def get_entities_related_to_a_collection(
     | suspected_threat_actors | List of related suspected threat actors        | collection   |
     | hunting_rulesets     | Google Threat Intelligence Yara rules that identify the given collection | hunting_ruleset |
 
+    Note on descriptors_only: When True, returns basic descriptors. When False, returns
+    detailed attributes.
+    IMPORTANT: `descriptors_only` must be `False` for the 'attack_techniques' relationship.
+    
     Args:
       id (required): Collection identifier.
       relationship_name (required): Relationship name.
-      descriptors_only (required): Bool. Must be True when the target object type is one of file, domain, url, ip_address or collection.
-      limit: Limit the number of collections to retrieve. 10 by default.
+      limit (optional): Limit the number of collections to retrieve. 10 by default.
+      descriptors_only (optional)): Bool. Default True. Must be False when the target object type is 'attack_techniques'.
     Returns:
       List of objects related to the collection.
   """

--- a/server/gti/gti_mcp/tools/intelligence.py
+++ b/server/gti/gti_mcp/tools/intelligence.py
@@ -37,6 +37,8 @@ async def search_iocs(query: str, ctx: Context, limit: int = 10, order_by: str =
     | domain        | creation_date, last_modification_date, last_update_date, positives                | last_modification_date- |
     | ip            | ip, last_modification_date, positives                                             | last_modification_date- |
 
+  Note: The `entity` modifier can only be used ONCE per query.
+
   You can find all available modifers at:
     - Files: https://gtidocs.virustotal.com/docs/file-search-modifiers
     - URLs: https://gtidocs.virustotal.com/docs/url-search-modifiers
@@ -64,6 +66,8 @@ async def search_iocs(query: str, ctx: Context, limit: int = 10, order_by: str =
             "query": query,
             "order": order_by},
         limit=limit)
+  if not isinstance(res, dict):
+    res = [o.to_dict() for o in res]
   return utils.sanitize_response(res)
 
 

--- a/server/gti/gti_mcp/tools/intelligence.py
+++ b/server/gti/gti_mcp/tools/intelligence.py
@@ -66,9 +66,7 @@ async def search_iocs(query: str, ctx: Context, limit: int = 10, order_by: str =
             "query": query,
             "order": order_by},
         limit=limit)
-  if not isinstance(res, dict):
-    res = [o.to_dict() for o in res]
-  return utils.sanitize_response(res)
+return utils.sanitize_response([o.to_dict() for o in res])
 
 
 @server.tool()


### PR DESCRIPTION
This PR updates function signatures and improves docstrings for GTI tools to enhance clarity and correctness.

### Changes:

*   **`server/gti/gti_mcp/tools/collections.py`**:
    *   Modified the function signature of `get_entities_related_to_a_collection`:
        *   Reordered parameters: `ctx` now comes before `limit`.
        *   Changed default value of `descriptors_only` to `True`.
    *   Updated docstrings to reflect the parameter changes and improve descriptions.
    *   Added a note about `descriptors_only` needing to be `False` for the 'attack_techniques' relationship.

*   **`server/gti/gti_mcp/tools/intelligence.py`**:
    *   Added a note to the `search_iocs` docstring clarifying that the `entity` modifier can only be used once per query.
    *   Ensured the response `res` is always a list by converting non-dict responses.
