### PR TITLE
fix: permission for publish workflow deployment status update action

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -316,6 +316,7 @@ jobs:
     needs: [detect_changes, display_summary]
     runs-on: ubuntu-latest
     name: Approve package publication
+    permissions: write-all
     environment:
       name: production # The workflow will continue only when approved
     if: ${{ needs.detect_changes.outputs.gti_changed == 'true' || 


### PR DESCRIPTION
### Summary
Updated permission for publish package workflow

### What
Updated `request_approval` action in `publish-packages.yml` with write permission.

### Why
Workflow was failing to update deployment status as Workflow does not have permission to write in repository