### PR TITLE
fix: SecOps SOAR package entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can install the packages using `uv tool install` (recommended):
 
 ```bash
 # Install packages
-uv tool install secops-mcp
+uv tool install google-secops-mcp
 uv tool install gti-mcp
 uv tool install scc-mcp
 uv tool install secops-soar-mcp
@@ -51,7 +51,7 @@ uv tool install secops-soar-mcp
 Alternatively, you can use pip:
 
 ```bash
-pip install secops-mcp
+pip install google-secops-mcp
 pip install gti-mcp
 pip install scc-mcp
 pip install secops-soar-mcp
@@ -63,7 +63,7 @@ After installation, you can run the servers directly using uvx:
 
 ```bash
 # Run SecOps MCP server
-uvx secops_mcp
+uvx secops-mcp
 
 # Run GTI MCP server
 uvx gti_mcp
@@ -94,7 +94,7 @@ You can configure MCP clients to use the installed packages with uvx. Here's an 
     "secops": {
       "command": "uvx",
       "args": [
-        "secops_mcp"
+        "secops-mcp"
       ],
       "env": {
         "CHRONICLE_PROJECT_ID": "your-project-id",
@@ -107,7 +107,7 @@ You can configure MCP clients to use the installed packages with uvx. Here's an 
     "gti": {
       "command": "uvx",
       "args": [
-        "gti-mcp"
+        "gti_mcp"
       ],
       "env": {
         "VT_APIKEY": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -118,7 +118,7 @@ You can configure MCP clients to use the installed packages with uvx. Here's an 
     "scc-mcp": {
       "command": "uvx",
       "args": [
-        "scc-mcp"
+        "scc_mcp"
       ],
       "env": {},
       "disabled": false,
@@ -158,6 +158,7 @@ You can also use environment files with uvx:
     }
   }
 }
+```
 
 ## Client Configurations
 The MCP servers from this repo can be used with the following clients

--- a/server/secops-soar/pyproject.toml
+++ b/server/secops-soar/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "secops-soar-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Google SecOps SOAR MCP server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -31,10 +31,10 @@ test = [
 ]
 
 [project.scripts]
-secops_soar_mcp = "secops_soar_mcp.server:main"
+secops_soar_mcp = "secops_soar_mcp.server:run_main"
 
 [project.entry-points.mcp]
-secops-soar = "secops_soar_mcp.server:main"
+secops-soar = "secops_soar_mcp.server:run_main"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/server/secops-soar/secops_soar_mcp/server.py
+++ b/server/secops-soar/secops_soar_mcp/server.py
@@ -94,7 +94,9 @@ def register_tools(integrations_arg: str):
                 if py_file.name == "__init__.py" or not py_file.is_file():
                     continue
 
-                module_stem = py_file.stem  # The filename without .py (e.g., "csv")
+                module_stem = (
+                    py_file.stem
+                )  # The filename without .py (e.g., "csv")
                 if module_stem not in enabled_integrations_set:
                     continue
                 module_import_path = f"marketplace.{module_stem}"  # The import path (e.g., "marketplace.csv")
@@ -167,6 +169,11 @@ async def main():
         logger.error("Error: %s", e)
     finally:
         await bindings.cleanup()
+
+
+def run_main():
+    """Entry point function that properly awaits the async main function."""
+    return asyncio.run(main())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
Fixed secops soard mcp server package entry and README markdown syntax

### What
- `server\secops-soar\secops_soar_mcp\server.py`: Added synchronous method for package entry
- `server\secops-soar\pyproject.toml`: Updated entry with synchronous method
- `README.md`: Fixed markdown syntax/typo and correct package name

### Why
- SecOps SOAR package invocation with uvx/standalone is failing with async error
- README had deformed section