### PR TITLE
Added new tool "get_detection_rule"

### DIFF
--- a/server/secops/README.md
+++ b/server/secops/README.md
@@ -23,6 +23,9 @@ Chronicle Security Operations suite.
 - **`search_security_rules(query, project_id=None, customer_id=None, region=None)`**
     - Searches security detection rules from Chronicle using regex.
 
+- **`get_detection_rule(rule_id, project_id=None, customer_id=None, region=None)`**
+    - Retrieves complete YARA-L detection rule code and metadata from Chronicle by Rule Id.
+
 - **`get_ioc_matches(project_id=None, customer_id=None, hours_back=24, max_matches=20, region=None)`**
     - Retrieves Indicators of Compromise (IoCs) matches from Chronicle within a specified time range.
 

--- a/server/secops/secops_mcp/tools/security_rules.py
+++ b/server/secops/secops_mcp/tools/security_rules.py
@@ -132,6 +132,87 @@ async def search_security_rules(
         return {'error': str(e), 'rules': []}
 
 @server.tool()
+async def get_detection_rule(
+    rule_id: str,
+    project_id: str = None,
+    customer_id: str = None,
+    region: str = None,
+) -> Dict[str, Any]:
+    """Retrieve the complete definition and metadata of a specific detection rule from Chronicle SIEM.
+
+    Fetches the full rule content including YARA-L code, metadata, configuration,
+    and status information for a specific detection rule by its RuleId. This is essential
+    for reviewing, analyzing, or modifying existing detection rules.
+
+    **Workflow Integration:**
+    - Use when you need to examine the complete logic and configuration of a specific detection rule.
+    - Essential for rule analysis, debugging, or understanding how a particular alert was generated.
+    - Useful for copying or modifying existing rules as templates for new detections.
+    - Critical for compliance audits or rule documentation processes.
+
+    **Use Cases:**
+    - Retrieve rule content to understand detection logic after an alert is triggered.
+    - Copy existing rule definitions as starting points for new custom rules.
+    - Analyze rule metadata and configuration for operational documentation.
+    - Review rule syntax and conditions for troubleshooting or optimization.
+    - Extract rule content for backup, version control, or migration purposes.
+    - Examine rule versioning and modification history.
+
+    **Rule Analysis Capabilities:**
+    - Complete YARA-L 2.0 rule text with all conditions and logic
+    - Rule metadata including description, author, severity, and MITRE mappings
+    - Rule configuration including severity, author, and scheduling frequency
+    - Version information and timestamps
+    - Associated rule ID, display name, and revision tracking
+
+    Args:
+        rule_id (str): Unique ID of the detection rule to retrieve.
+                      Examples: "ru_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" (latest version),
+                      "ru_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx@v_12345_67890" (specific version).
+                      If no version suffix is provided, the latest version is returned.
+        project_id (str): Google Cloud project ID. Defaults to environment configuration.
+        customer_id (str): Chronicle customer ID. Defaults to environment configuration.
+        region (str): Chronicle region (e.g., "us", "europe"). Defaults to environment configuration.
+
+    Returns:
+        Dict[str, Any]: Complete rule information including:
+                       - Rule text (YARA-L code)
+                       - Metadata (description, author, severity, etc.)
+                       - Configuration and status information
+                       - Version and timestamp details
+                       Returns error structure if the API call fails.
+
+    Example Usage:
+        # Get the latest version of a rule
+        rule_content = get_detection_rule("ru_661a3961-7370-4be7-abda-f233f7ff29ac")
+        
+        # Get a specific version of a rule
+        rule_content = get_detection_rule("ru_661a3961-7370-4be7-abda-f233f7ff29ac@v_1234567890_123456789")
+
+    Next Steps (using MCP-enabled tools):
+        - Analyze the rule text to understand detection logic and conditions.
+        - Use the rule content as a template for creating similar detection rules with `create_rule`.
+        - Test rule modifications using `test_rule` before deploying changes.
+        - Validate rule syntax using `validate_rule` if making modifications.
+        - Monitor rule performance using `get_rule_detections` and `list_rule_errors`.
+        - Document rule purpose and logic for operational teams and compliance audits.
+    """
+    try:
+        logger.info(f'Retrieving detection rule: {rule_id}')
+        
+        chronicle = get_chronicle_client(project_id, customer_id, region)
+        
+        # Get the rule using the client
+        rule_response = chronicle.get_rule(rule_id)
+        
+        logger.info(f'Successfully retrieved rule: {rule_id}')
+        return rule_response
+        
+    except Exception as e:
+        logger.error(f'Error retrieving detection rule {rule_id}: {str(e)}', exc_info=True)
+        return {'error': f'Error retrieving detection rule: {str(e)}', 'rule': {}}
+
+@server.tool()
 async def get_rule_detections(
     rule_id: str,
     alert_state: Optional[str] = None,


### PR DESCRIPTION
## Summary

This PR adds a new MCP tool `get_detection_rule` to the Google SecOps MCP server that enables retrieval of complete YARA-L detection rule definitions from Chronicle SIEM by rule ID.

## Motivation

Currently, the SecOps MCP server lacks the capability to retrieve the complete content and metadata of existing detection rules when a **specific Rule Id is provided**. Even though there already exists tools like `list_security_rules` & `search_security_rules`, they allow to get an exhaustive dump of all rules or get a list of few rules using regex searches; rather than targeted data.

This new tool adds an advantage while creating Runbooks for alert investigation, where the agent can have more context of the specific detection rule responsible for triggering the alert, compared to the existing tools which are a dump of multiple rules.

## Changes

### 1) New Tool Added

- **Tool Name**: `get_detection_rule`
- **File**: `server/secops/secops_mcp/tools/security_rules.py`
- **Function**: Retrieves complete detection rule definition including YARA-L code, metadata, and configuration

### 2) Updated the documentation
- **File**: `/server/secops/README.md`



## Implementation Details

The tool integrates with the existing secops wrapper([#Line51](https://github.com/google/secops-wrapper/blob/main/src/secops/chronicle/rule.py#L51)):
```python
chronicle = get_chronicle_client(project_id, customer_id, region)
rule_response = chronicle.get_rule(rule_id)
```
