### PR TITLE
fix: package name in setup.py for SecOps MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ After installation, you can run the servers directly using uvx:
 
 ```bash
 # Run SecOps MCP server
-uvx secops-mcp
+uvx --from google-secops-mcp secops-mcp
 
 # Run GTI MCP server
 uvx gti_mcp
@@ -94,6 +94,8 @@ You can configure MCP clients to use the installed packages with uvx. Here's an 
     "secops": {
       "command": "uvx",
       "args": [
+        "--from",
+        "google-secops-mcp",
         "secops-mcp"
       ],
       "env": {

--- a/server/secops/pyproject.toml
+++ b/server/secops/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-secops-mcp"
-version = "0.3.1"
+version = "0.4.0"
 description = "Google SecOps MCP server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server/secops/setup.py
+++ b/server/secops/setup.py
@@ -18,8 +18,8 @@ import setuptools
 setup = setuptools.setup
 
 setup(
-    name="secops-mcp",
-    version="0.1.0",
+    name="google-secops-mcp",
+    version="0.4.0",
     py_modules=["secops_mcp", "main"],  # Include both modules
     install_requires=[
         "fastmcp",
@@ -27,7 +27,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "secops-mcp=secops_mcp:main",
+            "secops-mcp=secops_mcp.server:main",
         ],
     },
 )


### PR DESCRIPTION
### Summary
Addresses a issue in the `google-secops-mcp` package that was causing import errors when users run the command `uvx --from google-secops-mcp secops_mcp`. The fix ensures proper module structure and consistent package configuration between `setup.py` and `pyproject.toml`.

### Purpose
When attempting to use the SecOps MCP package through `uvx`, encountered the error:
```
ModuleNotFoundError: No module named 'secops_mcp'
```
This occurred due to inconsistencies in how the package was defined and built, causing the Python interpreter to be unable to locate the `secops_mcp` module. These issues needed to be resolved to ensure a seamless installation and usage experience for our users.

### Changelog
- Updated package name to `google-secops-mcp` in `server/secops/setup.py`.
- Updated entry point in `server/secops/setup.py` with correct path/module.
- Updated `README.md` with correct `uvx` usage for SecOps MCP as `uvx secops-mcp` could point to different package.
- Incremented version to `0.4.0` in both `server/secops/pyproject.toml` and `server/secops/setup.py`.