### PR TITLE
fix: Add setuptools package discovery configuration to pyproject.toml

### DIFF
--- a/server/secops/pyproject.toml
+++ b/server/secops/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-secops-mcp"
-version = "0.4.0"
+version = "0.4.1"
 description = "Google SecOps MCP server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -43,3 +43,7 @@ secops_mcp = "secops_mcp.server:main"
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["secops_mcp*"]


### PR DESCRIPTION
## Summary

Fixes the ModuleNotFoundError when running `uvx --from google-secops-mcp secops_mcp` by adding proper package discovery configuration to pyproject.toml.

## Problem

When installing the package from PyPI, setuptools didn't know to include the `secops_mcp` package directory because the pyproject.toml was missing package discovery configuration. This caused:

```
ModuleNotFoundError: No module named 'secops_mcp'
```

## Solution

Added `[tool.setuptools.packages.find]` section to pyproject.toml to explicitly tell setuptools to include the `secops_mcp` package and its subpackages.

## Test Plan

- Built package locally with `python -m build`
- Verified `secops_mcp` directory is included in the wheel
- Tested with `uvx --from . secops_mcp --help` successfully
- Package now properly installs and runs

## Changes

- Added setuptools package discovery configuration
- Bumped version to 0.4.1