### PR TITLE
fix: correct .dockerignore pattern to prevent credential exposure

### DIFF
--- a/run-with-google-adk/.dockerignore
+++ b/run-with-google-adk/.dockerignore
@@ -1,1 +1,21 @@
-run-with-google-adk/google-mcp-security-agent/.env
+# Environment files containing credentials
+run-with-google-adk/google_mcp_security_agent/.env
+google_mcp_security_agent/.env
+.env
+*.env
+.env.*
+
+# Additional credential files
+*.key
+*.json
+*.pem
+credentials/
+secrets/
+
+# Development files
+.git/
+.gitignore
+*.pyc
+__pycache__/
+.pytest_cache/
+.coverage


### PR DESCRIPTION
Fixes the incorrect directory name pattern in .dockerignore that could lead to credential exposure in Docker images.

The .dockerignore file contained an incorrect path pattern:
- Incorrect: run-with-google-adk/google-mcp-security-agent/.env (hyphens)
- Actual directory: run-with-google-adk/google_mcp_security_agent/ (underscores)

This mismatch caused .env files containing sensitive credentials to be included in Docker images.

Fixed the directory pattern and added comprehensive patterns to exclude all environment and credential files.

Resolves #192