### PR TITLE
Fix SecOps authentication requirements and hanging issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ With environment variables:
 CHRONICLE_PROJECT_ID="your-project-id" \
 CHRONICLE_CUSTOMER_ID="01234567-abcd-4321-1234-0123456789ab" \
 CHRONICLE_REGION="us" \
+GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json" \
 uvx secops_mcp
 ```
 
@@ -101,7 +102,8 @@ You can configure MCP clients to use the installed packages with uvx. Here's an 
       "env": {
         "CHRONICLE_PROJECT_ID": "your-project-id",
         "CHRONICLE_CUSTOMER_ID": "01234567-abcd-4321-1234-0123456789ab",
-        "CHRONICLE_REGION": "us"
+        "CHRONICLE_REGION": "us",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/your/service-account-key.json"
       },
       "disabled": false,
       "autoApprove": []
@@ -122,7 +124,9 @@ You can configure MCP clients to use the installed packages with uvx. Here's an 
       "args": [
         "scc_mcp"
       ],
-      "env": {},
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/your/service-account-key.json"
+      },
       "disabled": false,
       "autoApprove": []
     },

--- a/docs/servers/secops_mcp.md
+++ b/docs/servers/secops_mcp.md
@@ -28,10 +28,9 @@ Add the following configuration to your MCP client's settings file:
       "env": {
         "CHRONICLE_PROJECT_ID": "your-gcp-project-id",
         "CHRONICLE_CUSTOMER_ID": "your-chronicle-customer-id",
-        "CHRONICLE_REGION": "us"
+        "CHRONICLE_REGION": "us",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/your/service-account-key.json"
       },
-      "disabled": false,
-      "autoApprove": []
       "disabled": false,
       "autoApprove": []
     }
@@ -63,6 +62,7 @@ Example .env file:
 CHRONICLE_PROJECT_ID=your-gcp-project-id
 CHRONICLE_CUSTOMER_ID=your-chronicle-customer-id
 CHRONICLE_REGION=us
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account-key.json
 ```
 
 ### Environment Variable Setup
@@ -74,6 +74,7 @@ Set up these environment variables in your system:
 export CHRONICLE_PROJECT_ID="your-google-cloud-project-id"
 export CHRONICLE_CUSTOMER_ID="your-chronicle-customer-id"
 export CHRONICLE_REGION="us"
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json"
 ```
 
 **For Windows PowerShell:**
@@ -81,6 +82,7 @@ export CHRONICLE_REGION="us"
 $Env:CHRONICLE_PROJECT_ID = "your-google-cloud-project-id"
 $Env:CHRONICLE_CUSTOMER_ID = "your-chronicle-customer-id"
 $Env:CHRONICLE_REGION = "us"
+$Env:GOOGLE_APPLICATION_CREDENTIALS = "/path/to/your/service-account-key.json"
 ```
 
 The `CHRONICLE_REGION` can be one of:

--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -95,7 +95,8 @@ Additionally, for the secops-soar MCP server, you will need use the CA list bund
       "env": {
         "CHRONICLE_PROJECT_ID": "your-project-id",
         "CHRONICLE_CUSTOMER_ID": "01234567-abcd-4321-1234-0123456789ab",
-        "CHRONICLE_REGION": "us"
+        "CHRONICLE_REGION": "us",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/your/service-account-key.json"
       },
       "disabled": false,
       "autoApprove": []
@@ -139,7 +140,9 @@ Additionally, for the secops-soar MCP server, you will need use the CA list bund
         "run",
         "scc_mcp.py"
       ],
-      "env": {},
+      "env": {
+        "GOOGLE_APPLICATION_CREDENTIALS": "/path/to/your/service-account-key.json"
+      },
       "disabled": false,
       "autoApprove": []
     }
@@ -175,6 +178,7 @@ Add these lines to your `~/.bashrc`, `~/.zshrc`, or equivalent shell configurati
 export CHRONICLE_PROJECT_ID="your-google-cloud-project-id"
 export CHRONICLE_CUSTOMER_ID="your-chronicle-customer-id"
 export CHRONICLE_REGION="us"
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json"
 
 # SOAR
 export SOAR_URL="your-soar-url"

--- a/server/secops/README.md
+++ b/server/secops/README.md
@@ -181,7 +181,8 @@ Add the following configuration to your MCP client's settings file:
       "env": {
         "CHRONICLE_PROJECT_ID": "${CHRONICLE_PROJECT_ID}",
         "CHRONICLE_CUSTOMER_ID": "${CHRONICLE_CUSTOMER_ID}",
-        "CHRONICLE_REGION": "${CHRONICLE_REGION}"
+        "CHRONICLE_REGION": "${CHRONICLE_REGION}",
+        "GOOGLE_APPLICATION_CREDENTIALS": "${GOOGLE_APPLICATION_CREDENTIALS}"
       },
       "disabled": false,
       "autoApprove": []
@@ -206,7 +207,8 @@ You can also use pip instead of uv to install and run the MCP server:
       "env": {
         "CHRONICLE_PROJECT_ID": "${CHRONICLE_PROJECT_ID}",
         "CHRONICLE_CUSTOMER_ID": "${CHRONICLE_CUSTOMER_ID}",
-        "CHRONICLE_REGION": "${CHRONICLE_REGION}"
+        "CHRONICLE_REGION": "${CHRONICLE_REGION}",
+        "GOOGLE_APPLICATION_CREDENTIALS": "${GOOGLE_APPLICATION_CREDENTIALS}"
       },
       "disabled": false,
       "autoApprove": [
@@ -236,6 +238,7 @@ Set up these environment variables in your system:
 export CHRONICLE_PROJECT_ID="your-google-cloud-project-id"
 export CHRONICLE_CUSTOMER_ID="your-chronicle-customer-id"
 export CHRONICLE_REGION="us"
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/your/service-account-key.json"
 ```
 
 **For Windows PowerShell:**
@@ -243,6 +246,7 @@ export CHRONICLE_REGION="us"
 $Env:CHRONICLE_PROJECT_ID = "your-google-cloud-project-id"
 $Env:CHRONICLE_CUSTOMER_ID = "your-chronicle-customer-id"
 $Env:CHRONICLE_REGION = "us"
+$Env:GOOGLE_APPLICATION_CREDENTIALS = "/path/to/your/service-account-key.json"
 ```
 
 The `CHRONICLE_REGION` can be one of:


### PR DESCRIPTION
Fixes #189

Add GOOGLE_APPLICATION_CREDENTIALS to all SecOps documentation examples and implement authentication error handling with timeout to prevent hanging when credentials are missing.