### PR TITLE
fix typehint

### DIFF
--- a/server/secops/secops_mcp/tools/security_alerts.py
+++ b/server/secops/secops_mcp/tools/security_alerts.py
@@ -17,7 +17,7 @@ import json
 import logging
 from datetime import datetime, timedelta, timezone
 
-from typing import Any, Dict, Optional, Literal, Union
+from typing import Any, Dict, Optional
 from secops_mcp.server import get_chronicle_client, server
 
 
@@ -215,8 +215,8 @@ async def do_update_security_alert(
     status: Optional[str] = None,
     verdict: Optional[str] = None,
     severity: Optional[int] = None,
-    comment: Optional[Union[str, Literal[""]]] = None,
-    root_cause: Optional[Union[str, Literal[""]]] = None
+    comment: Optional[str] = None,
+    root_cause: Optional[str] = None
 ) -> str:
     """
         Update security alert attributes directly in Chronicle SIEM.


### PR DESCRIPTION
Close #199 

When deployed to Agent Engine, any prompt raises:
```
do_update_security_alert functionDeclaration parameters.comment schema didn't specify the schema type field.
```

This is resolved with:
```diff
- comment: Optional[Union[str, Literal[""]]] = None,
+ comment: Optional[str] = None,
```

The problematic pattern was specifically Optional[Union[str, Literal[""]]] which combined Optional with Union with Literal for an empty string and confused the schema generator. The simple Union[str, dict] patterns are standard and _should_ work fine too but we are using `Optional[str] = None` after #195, so following that pattern here too.



