### PR TITLE
fix(tools): Handle API errors in collections toolHandle errors

### DIFF
--- a/server/gti/gti_mcp/tools/collections.py
+++ b/server/gti/gti_mcp/tools/collections.py
@@ -392,9 +392,13 @@ async def get_collection_timeline_events(id: str, ctx: Context):
     List of events related to the given collection.
   """
   async with vt_client(ctx) as client:
-    data = await client.get_async(f"/collections/{id}/timeline/events")
-    data = await data.json_async()
-  return utils.sanitize_response(data["data"])
+    resp = await client.get_async(f"/collections/{id}/timeline/events")
+    if resp.status != 200:
+        error_json = await resp.json_async()
+        error_info = error_json.get("error", {})
+        return [{"error": f"API Error: {error_info.get('message', 'Unknown error')}"}]
+    data = await resp.json_async()
+  return utils.sanitize_response(data.get("data", []))
 
 
 @server.tool()
@@ -407,9 +411,13 @@ async def get_collection_mitre_tree(id: str, ctx: Context) -> typing.Dict:
     A dictionary including the tactics and techniques associated to the given threat.
   """
   async with vt_client(ctx) as client:
-    data = await client.get_async(f"/collections/{id}/mitre_tree")
-    data = await data.json_async()
-  return utils.sanitize_response(data["data"])
+    resp = await client.get_async(f"/collections/{id}/mitre_tree")
+    if resp.status != 200:
+        error_json = await resp.json_async()
+        error_info = error_json.get("error", {})
+        return {"error": f"API Error: {error_info.get('message', 'Unknown error')}"}
+    data = await resp.json_async()
+  return utils.sanitize_response(data.get("data", {}))
 
 
 @server.tool()
@@ -620,8 +628,12 @@ async def get_collection_feature_matches(
     }
     
     response = await client.get_async(f"/collections/{collection_id}/features/search", params=params)
+    if response.status != 200:
+        error_json = await response.json_async()
+        error_info = error_json.get("error", {})
+        return [{"error": f"API Error: {error_info.get('message', 'Unknown error')}"}]
     data = await response.json_async()
-    return utils.sanitize_response(data["data"])
+    return utils.sanitize_response(data.get("data", []))
 
 
 @server.tool()

--- a/server/gti/tests/test_collections_errors.py
+++ b/server/gti/tests/test_collections_errors.py
@@ -1,0 +1,98 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+from unittest.mock import MagicMock, AsyncMock, patch
+from mcp.server.fastmcp import Context
+from gti_mcp.tools import collections
+
+@pytest.mark.asyncio
+async def test_get_collection_timeline_events_api_error_handled():
+    """Test get_collection_timeline_events returns error dict on API error (e.g. 404)."""
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_response = MagicMock()
+    mock_response.status = 404
+    async def json_async():
+        return {"error": {"message": "Collection not found"}}
+    mock_response.json_async = json_async
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_async = AsyncMock(return_value=mock_response)
+
+    mock_vt_client = MagicMock()
+    mock_vt_client.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_vt_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("gti_mcp.tools.collections.vt_client", return_value=mock_vt_client):
+        result = await collections.get_collection_timeline_events(id="non_existent_id", ctx=mock_ctx)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "Collection not found" in result[0]["error"]
+
+@pytest.mark.asyncio
+async def test_get_collection_mitre_tree_api_error_handled():
+    """Test get_collection_mitre_tree returns error dict on API error (e.g. 404)."""
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_response = MagicMock()
+    mock_response.status = 404
+    async def json_async():
+        return {"error": {"message": "Collection not found"}}
+    mock_response.json_async = json_async
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_async = AsyncMock(return_value=mock_response)
+
+    mock_vt_client = MagicMock()
+    mock_vt_client.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_vt_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("gti_mcp.tools.collections.vt_client", return_value=mock_vt_client):
+        result = await collections.get_collection_mitre_tree(id="non_existent_id", ctx=mock_ctx)
+        assert "error" in result
+        assert "Collection not found" in result["error"]
+
+@pytest.mark.asyncio
+async def test_get_collection_feature_matches_api_error_handled():
+    """Test get_collection_feature_matches returns error dict on API error (e.g. 404)."""
+    mock_ctx = MagicMock(spec=Context)
+
+    mock_response = MagicMock()
+    mock_response.status = 404
+    async def json_async():
+        return {"error": {"message": "Collection not found"}}
+    mock_response.json_async = json_async
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_async = AsyncMock(return_value=mock_response)
+
+    mock_vt_client = MagicMock()
+    mock_vt_client.__aenter__ = AsyncMock(return_value=mock_client_instance)
+    mock_vt_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("gti_mcp.tools.collections.vt_client", return_value=mock_vt_client):
+        result = await collections.get_collection_feature_matches(
+            collection_id="non_existent_id",
+            feature_type="ft",
+            feature_id="fid",
+            entity_type="file",
+            search_space="collection",
+            entity_type_plural="ets",
+            ctx=mock_ctx
+        )
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert "Collection not found" in result[0]["error"]


### PR DESCRIPTION
**Description:**

## Summary

This pull request adds robust error handling to the `collections` tool. Previously, if the underlying API returned an error (e.g., a 404 Not Found), the tool would fail without providing a clear error message. With these changes, the tool now gracefully handles API errors and returns a structured error message, improving the tool's resilience and user experience.

## Changes

### `server/gti/gti_mcp/tools/collections.py`

*   **Error Handling:** The functions `get_collection_timeline_events`, `get_collection_mitre_tree`, and `get_collection_feature_matches` now check the HTTP status of the API response.
*   If the status is not 200, the functions extract the error message from the response body and return a dictionary with an `error` key.
*   **Safe Data Access:** The code now uses `.get("data", ...)` to safely access the `data` key in the JSON response, preventing potential `KeyError` exceptions.

### `server/gti/tests/test_collections_errors.py`

*   A new test file has been added to verify the new error handling logic.
*   The tests simulate API errors (HTTP 404) and assert that the tool functions return the expected error dictionaries.

These changes ensure that the `collections` tool is more robust and provides better feedback when encountering API-level issues.

