### PR TITLE
Update dependencies to latest and increment google-secops-mcp

### DIFF
--- a/server/secops/pyproject.toml
+++ b/server/secops/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-secops-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "Google SecOps MCP server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -15,11 +15,11 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "mcp[cli]>=1.4.1",
-    "secops>=0.18.0",
-    "google-auth>=2.38.0",
-    "google-auth-httplib2>=0.2.0",
-    "google-api-python-client>=2.164.0"
+    "mcp[cli]>=1.23.0",
+    "secops>=0.29.0",
+    "google-auth>=2.45.0",
+    "google-auth-httplib2>=0.3.0",
+    "google-api-python-client>=2.187.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
We've merged several changes that aren't available to end users when they install via PyPI, so it would be good to create this new release. While we're at it, I also updated the dependencies to the latest.