### PR TITLE
feat: make SOAR SSL verification configurable

### DIFF
--- a/server/secops-soar/pyproject.toml
+++ b/server/secops-soar/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.11.15",
-    "mcp[cli]>=1.4.1"
+    "certifi>=2026.1.4",
+    "mcp[cli]>=1.4.1",
 ]
 
 [project.optional-dependencies]

--- a/server/secops-soar/secops_soar_mcp/bindings.py
+++ b/server/secops-soar/secops_soar_mcp/bindings.py
@@ -41,12 +41,20 @@ async def _get_valid_scopes():
 async def bind():
     """Binds global variables."""
     global http_client, valid_scopes
+    
+    # Parse SSL_VERIFY from env, default to True if not set
+    ssl_verify_raw = os.getenv(consts.ENV_SOAR_SSL_VERIFY, "true").lower()
+    ssl_verify = ssl_verify_raw == "true"
+
     http_client = HttpClient(
-        os.getenv(consts.ENV_SOAR_URL), os.getenv(consts.ENV_SOAR_APP_KEY)
+        os.getenv(consts.ENV_SOAR_URL),
+        os.getenv(consts.ENV_SOAR_APP_KEY),
+        ssl_verify
     )
     valid_scopes = await _get_valid_scopes()
 
 
 async def cleanup():
     """Cleans up global variables."""
-    await http_client.close()
+    if http_client:
+        await http_client.close()

--- a/server/secops-soar/secops_soar_mcp/http_client.py
+++ b/server/secops-soar/secops_soar_mcp/http_client.py
@@ -25,10 +25,11 @@ logger = get_logger(__name__)
 class HttpClient:
     """HTTP client for making requests to the SecOps SOAR API."""
 
-    def __init__(self, base_url: str, app_key: str):
+    def __init__(self, base_url: str, app_key: str, ssl_verify: bool = True):
         self.base_url = base_url
         self.app_key = app_key
         self._session = None
+        self.ssl_verify = ssl_verify
 
     def _get_session(self) -> aiohttp.ClientSession:
         if self._session is None:
@@ -58,7 +59,7 @@ class HttpClient:
         headers = await self._get_headers()
         try:
             async with self._get_session().get(
-                self.base_url + endpoint, params=params, headers=headers
+                self.base_url + endpoint, params=params, headers=headers, ssl=self.ssl_verify
             ) as response:
                 response.raise_for_status()  # Raise an exception for 4xx/5xx responses
                 return await response.json()
@@ -87,7 +88,7 @@ class HttpClient:
         headers = await self._get_headers()
         try:
             async with self._get_session().post(
-                self.base_url + endpoint, json=req, params=params, headers=headers
+                self.base_url + endpoint, json=req, params=params, headers=headers, ssl=self.ssl_verify
             ) as response:
                 response.raise_for_status()
                 data = await response.content.read()
@@ -118,7 +119,7 @@ class HttpClient:
         headers = await self._get_headers()
         try:
             async with self._get_session().patch(
-                self.base_url + endpoint, json=req, params=params, headers=headers
+                self.base_url + endpoint, json=req, params=params, headers=headers, ssl=self.ssl_verify
             ) as response:
                 response.raise_for_status()
                 return await response.json()
@@ -129,4 +130,5 @@ class HttpClient:
         return None
 
     async def close(self):
-        await self._get_session().close()
+        if self._session:
+            await self._get_session().close()

--- a/server/secops-soar/secops_soar_mcp/utils/consts.py
+++ b/server/secops-soar/secops_soar_mcp/utils/consts.py
@@ -15,7 +15,7 @@
 
 ENV_SOAR_URL = "SOAR_URL"
 ENV_SOAR_APP_KEY = "SOAR_APP_KEY"
-
+ENV_SOAR_SSL_VERIFY = "SOAR_SSL_VERIFY"
 
 class Endpoints:
     """Endpoints for SOAR."""
@@ -40,3 +40,4 @@ class Endpoints:
     LIST_INVOLVED_EVENTS_BY_ALERT = (
         "/api/1p/external/v1.0/cases/{CASE_ID}/alerts/{ALERT_ID}/involvedEvents"
     )
+    


### PR DESCRIPTION
## Summary
This PR adds the ability to configure SSL/TLS verification for the SecOps SOAR MCP server. This is useful as a last resort for environments with self-signed certificates or proxy-level TLS interception.

## Changes
- **http_client.py**: Updated HttpClient to use aiohttp's ssl parameter instead of verify. Restored ssl_verify parameter in request methods.
- **bindings.py**: Added logic to read SOAR_SSL_VERIFY from environment variables (defaults to true). Handles string-to-bool conversion.
- **consts.py**: Added ENV_SOAR_SSL_VERIFY constant.
- **pyproject.toml**: Added certifi dependency.

## Usage
Set the environment variable SOAR_SSL_VERIFY=false to disable certificate verification (only for the SOAR API URL).