### PR TITLE
Update scc_mcp.py

### DIFF
--- a/server/scc/scc_mcp.py
+++ b/server/scc/scc_mcp.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List
 
 from google.api_core import exceptions as google_exceptions
 from google.cloud import asset_v1
-from google.cloud import securitycenter
+from google.cloud import securitycenter_v2
 from google.protobuf import json_format 
 from mcp.server.fastmcp import FastMCP
 
@@ -41,7 +41,7 @@ logging.getLogger().addHandler(handler)
 # Ensure ADC are configured in the environment where the server runs
 # (e.g., by running `gcloud auth application-default login`).
 try:
-    scc_client = securitycenter.SecurityCenterClient()
+    scc_client = securitycenter_v2.SecurityCenterClient()
     logger.info("Successfully initialized Google Cloud Security Center Client.")
 except Exception as e:
     logger.error(f"Failed to initialize Security Center Client: {e}", exc_info=True)


### PR DESCRIPTION
On August 29, 2025, user @huydd79 proposed two changes to fix the version of SCC used by the SCC MCP server in mcp-security.  This fix implements the proposed change, which involves modifying lines 20 and 44 in scc_mcp.py in order to implement v2 of the SCC API rather than the previous version.