### PR TITLE
Security fix: Add path validation to analyse_file tool (CWE-22)

### DIFF
--- a/server/gti/gti_mcp/tools/files.py
+++ b/server/gti/gti_mcp/tools/files.py
@@ -259,8 +259,15 @@ async def analyse_file(file_path: str, ctx: Context):
   Returns:
     The analysis report.
   """
+  import os
+  resolved = os.path.realpath(os.path.abspath(file_path))
+  allowed_dir = os.path.realpath("/tmp/gti-uploads")
+  if not resolved.startswith(allowed_dir + os.sep):
+      raise ValueError(
+          f"Access denied: file_path must be within {allowed_dir}"
+      )
   async with vt_client(ctx) as client:
-    with open(file_path, "rb") as f:    
+    with open(resolved, "rb") as f:
       analysis = await client.scan_file_async(file=f)
       logging.info(f"File {file_path} uploaded.")
 


### PR DESCRIPTION
## Summary

The analyse_file tool was passing user-supplied file_path directly 
to open() with no validation, allowing path traversal attacks.

## Vulnerability Details

File: server/gti/gti_mcp/tools/files.py, line 263
CWE-22 (Path Traversal) + CWE-200 (Sensitive Data Exposure)

An attacker with MCP client access could call:
  analyse_file(file_path="/proc/self/environ")

This causes the server to read its own environment variables 
including VT_APIKEY and upload them to VirusTotal.

## Fix

Added os.path.realpath() validation to restrict file access 
to /tmp/gti-uploads directory before opening any file.