### PR TITLE
docs: explain how to find SOAR_URL

### DIFF
--- a/docs/servers/secops_soar_mcp.md
+++ b/docs/servers/secops_soar_mcp.md
@@ -80,6 +80,8 @@ $Env:SOAR_APP_KEY = "your-soar-api-key"
 
 For more detailed instructions on setting up environment variables, refer to the [usage guide](../usage_guide.md#setting-up-environment-variables).
 
+If the server closes with a `Failed to fetch valid scopes from SOAR` error, confirm that `SOAR_URL` points to your SOAR base URL rather than your Backstory URL. The [usage guide](../usage_guide.md) includes steps for finding the correct value.
+
 ### Available Integrations
 
 The `--integrations` flag in the server configuration allows you to enable specific integrations. The integration modules are located in the `marketplace/` directory. Here's a subset of the available integrations:

--- a/docs/usage_guide.md
+++ b/docs/usage_guide.md
@@ -244,3 +244,21 @@ If you encounter issues with the MCP servers:
 3. **Check server logs**: Look for error messages in the server output
 4. **Restart the client**: Sometimes restarting the LLM Desktop or VS Code can resolve connection issues
 5. **Verify uv installation**: Ensure that `uv` is properly installed and accessible in your PATH
+
+### SecOps SOAR: finding the correct SOAR_URL
+
+If the SecOps SOAR server starts and then shuts down with an error like this:
+
+```text
+Error: Failed to fetch valid scopes from SOAR, please make sure you have configured the right SOAR credentials. Shutting down...
+MCP error -32000: Connection closed
+```
+
+check that `SOAR_URL` is set to your Google SecOps SOAR base URL, not your Backstory URL. The SOAR APIs used by this server are specific to the SOAR platform, so they are not listed in a Backstory tenant's Swagger documentation.
+
+If you are not sure which URL to use, try one of these options:
+
+1. In Google SecOps SOAR, go to **Settings > Webhooks**, create a new webhook with any parameters, and copy the base URL from the generated webhook URL. For example: `https://s4i0z.siemplify-soar.com`.
+2. Open your browser developer tools, go to the **Network** tab, and navigate to **Cases** in the SOAR UI. Look for a request such as `GetCaseCardsByRequest`, open the **Headers** tab, and copy the base URL from that request. For example: `https://s4i0z.siemplify-soar.com`.
+
+After updating `SOAR_URL`, restart your MCP client so it picks up the new environment variable.


### PR DESCRIPTION
This adds a small troubleshooting note for the SecOps SOAR `SOAR_URL` setup path.

What changed:
- documents the `Failed to fetch valid scopes from SOAR` startup error
- clarifies that `SOAR_URL` should be the SOAR base URL, not the Backstory URL
- adds two practical ways to find the correct base URL from the SOAR UI
- links the SecOps SOAR server page back to the usage guide

Closes #96

Validation:
- Ran `python -m sphinx -b html docs docs\_build\html` successfully.
- The build still reports existing documentation warnings unrelated to this change, mostly missing toctree entries and pre-existing cross-reference warnings.