### PR TITLE
fix: correct case details response key

### DIFF
--- a/server/secops-soar/secops_soar_mcp/case_management.py
+++ b/server/secops-soar/secops_soar_mcp/case_management.py
@@ -557,7 +557,7 @@ def register_tools(mcp: FastMCP):
         )
         results = await asyncio.gather(case_coro, case_alerts_coro, case_comments_coro)
         return {
-            "case_details:": results[0],
+            "case_details": results[0],
             "case_alerts": results[1],
             "case_comments": results[2],
         }


### PR DESCRIPTION
`get_case_full_details` currently returns the case payload under `case_details:`, with a trailing colon in the key name.

This changes the key to `case_details`, matching the surrounding `case_alerts` and `case_comments` keys and making the response easier for callers to consume consistently.

Tests:
- `python3 -m py_compile server/secops-soar/secops_soar_mcp/case_management.py`
- `git diff --check`
