### PR TITLE
fix: make SOAR cleanup idempotent

### DIFF
--- a/server/secops-soar/secops_soar_mcp/bindings.py
+++ b/server/secops-soar/secops_soar_mcp/bindings.py
@@ -49,4 +49,6 @@ async def bind():
 
 async def cleanup():
     """Cleans up global variables."""
+    if http_client is None:
+        return
     await http_client.close()


### PR DESCRIPTION
`bindings.cleanup()` currently assumes `http_client` was initialized. If startup fails before `bind()` completes, cleanup can raise a secondary `AttributeError` while handling the original error.

This makes cleanup return early when no client has been created yet.

Tests:
- `python3 -m py_compile server/secops-soar/secops_soar_mcp/bindings.py`
- `git diff --check`
