### PR TITLE
fix: declare SOAR dotenv dependency

### DIFF
--- a/server/secops-soar/pyproject.toml
+++ b/server/secops-soar/pyproject.toml
@@ -15,7 +15,8 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp>=3.11.15",
-    "mcp[cli]>=1.4.1,<2.0"
+    "mcp[cli]>=1.4.1,<2.0",
+    "python-dotenv>=1.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
The SecOps SOAR package imports `dotenv` from `secops_soar_mcp.bindings`, but `python-dotenv` is not listed in the package dependencies.

This adds the missing runtime dependency to `server/secops-soar/pyproject.toml`.

Tests:
- `python3 -m py_compile server/secops-soar/secops_soar_mcp/bindings.py`
- `python3 -m pip install --dry-run ./server/secops-soar` (metadata prepared; dependency resolution then stopped because the local Python is 3.9 and the existing `mcp>=1.4.1` requirement needs Python 3.10+)
- `git diff --check`
