### PR TITLE
fix: avoid creating SOAR session on close

### DIFF
--- a/server/secops-soar/secops_soar_mcp/http_client.py
+++ b/server/secops-soar/secops_soar_mcp/http_client.py
@@ -129,4 +129,5 @@ class HttpClient:
         return None
 
     async def close(self):
-        await self._get_session().close()
+        if self._session is not None:
+            await self._session.close()


### PR DESCRIPTION
`HttpClient.close()` should only close an existing aiohttp session. Calling `_get_session()` inside `close()` creates a new session just to close it, which gives cleanup an unnecessary side effect.

This skips the close call when no session has been created yet.

Tests:
- `python3 -m py_compile server/secops-soar/secops_soar_mcp/http_client.py`
- `PYTHONPATH=/tmp/mcp-security-http-deps:server/secops-soar python3 - <<'PY' ...` smoke test for closing a client before any request creates a session
- `git diff --check`
