### PR TITLE
fix: align SOAR setup entrypoint

### DIFF
--- a/server/secops-soar/setup.py
+++ b/server/secops-soar/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "secops-soar-mcp=secops_soar_mcp.server:main",
+            "secops-soar-mcp=secops_soar_mcp.server:run_main",
         ],
     },
 )


### PR DESCRIPTION
The legacy `server/secops-soar/setup.py` console script points at the async `main` coroutine. That can create an entrypoint which returns a coroutine instead of running the server.

This aligns the setup.py entrypoint with pyproject.toml by using `run_main`, and also updates the setup.py version to match the package version in pyproject.toml.

Tests:
- `python3 -m py_compile server/secops-soar/setup.py`
- `python3 setup.py --name --version` from `server/secops-soar`
- `git diff --check`
