### PR TITLE
Exclude noisy fields from collection and file behavior responses

### DIFF
--- a/server/gti/gti_mcp/tools/collections.py
+++ b/server/gti/gti_mcp/tools/collections.py
@@ -43,6 +43,80 @@ COLLECTION_KEY_RELATIONSHIPS = [
 ]
 COLLECTION_EXCLUDED_ATTRS = ",".join(["aggregations"])
 
+# Fields stripped client-side from the `attributes.aggregations.files`
+# section of the response of `get_collections_commonalities`. The API's
+# `exclude_attributes` param only works at whole-attribute granularity (e.g.
+# dropping all of `aggregations`, as COLLECTION_EXCLUDED_ATTRS does above),
+# so it can't remove nested sub-fields while keeping the rest of
+# `aggregations.files`; these are removed after the fact instead. They are
+# either too verbose/noisy or too large for regular consumption.
+COLLECTION_COMMONALITIES_FILES_EXCLUDED_ATTRS = [
+    "itw_urls",
+    "execution_parents",
+    "compressed_parents",
+    "pcap_parents",
+    "dropped_files_sha256",
+    "email_parents",
+    "tags",
+    "main_icon_dhash",
+    "main_icon_raw_md5",
+    "vhash",
+    "imphash",
+    "behash",
+    "tlshhash",
+    "attributions",
+    "crowdsourced_ids_results",
+    "crowdsourced_yara_results",
+    "embedded_domains",
+    "embedded_ips",
+    "mutexes_created",
+    "mutexes_opened",
+    "registry_keys_deleted",
+    "registry_keys_opened",
+    "registry_keys_set",
+    "file_types",
+    "crowdsourced_sigma_results",
+    "debug_codeview_guids",
+    "debug_codeview_names",
+    "debug_timestamps",
+    "dropped_files_path",
+    "exiftool_authors",
+    "exiftool_create_dates",
+    "exiftool_creators",
+    "exiftool_last_printed",
+    "exiftool_producers",
+    "exiftool_subjects",
+    "exiftool_titles",
+    "filecondis_dhash",
+    "netassembly_mvid",
+    "office_application_names",
+    "office_authors",
+    "office_creation_datetimes",
+    "office_last_saved",
+    "pe_info_imports",
+    "pe_info_exports",
+    "pe_info_section_md5",
+    "pe_info_section_names",
+    "sandbox_verdicts",
+    "memory_pattern_urls",
+    "embedded_urls",
+    "parent_contacted_domains",
+]
+
+# Fields excluded (via the `exclude_attributes` API param, on top of
+# COLLECTION_EXCLUDED_ATTRS) from `search_vulnerabilities` results. These are
+# specific to the "vulnerability" collection type and either too
+# verbose/noisy or too large for regular consumption.
+VULNERABILITY_EXCLUDED_ATTRS = [
+    "cpes",
+    "vendor_fix_references",
+    "sources",
+    "version_history",
+    "field_sources",
+    "tags_details",
+    "alt_names_details",
+]
+
 COLLECTION_TYPES = {
     "threat-actor",
     "malware-family",
@@ -142,6 +216,7 @@ async def _search_threats_by_collection_type(
     ctx: Context,
     limit: int = 10,
     order_by: str = "relevance-",
+    extra_excluded_attrs: typing.List[str] | None = None,
 ) -> typing.List[typing.Dict[str, typing.Any]]:
   """Search a given threat type in the Google Threat Intelligence platform,
 
@@ -150,6 +225,9 @@ async def _search_threats_by_collection_type(
     collection_type (required): Collection type. One of: "threat-actor", "malware-family", "campaign", "report", "vulnerability", "collection".
     limit: Limit the number of threats to retrieve. 10 by default.
     order_by: Order results by the given order key. "relevance-" by default.
+    extra_excluded_attrs: Additional attribute names to exclude, on top of
+      COLLECTION_EXCLUDED_ATTRS, for collection types with their own noisy
+      fields (e.g. vulnerabilities).
 
   Returns:
     List of collections, aka threats.
@@ -157,6 +235,10 @@ async def _search_threats_by_collection_type(
   if collection_type not in COLLECTION_TYPES:
       raise ValueError(
           f"wrong collection_type. Available collection_type are: {','.join(COLLECTION_TYPES)} ")
+
+  exclude_attributes = COLLECTION_EXCLUDED_ATTRS
+  if extra_excluded_attrs:
+    exclude_attributes = ",".join([COLLECTION_EXCLUDED_ATTRS, *extra_excluded_attrs])
 
   async with vt_client(ctx) as client:
     res = await utils.consume_vt_iterator(
@@ -166,7 +248,7 @@ async def _search_threats_by_collection_type(
             "filter": f"collection_type:{collection_type} {query}",
             "order": order_by,
             "relationships": COLLECTION_KEY_RELATIONSHIPS,
-            "exclude_attributes": COLLECTION_EXCLUDED_ATTRS,
+            "exclude_attributes": exclude_attributes,
         },
         limit=limit,
     )
@@ -372,7 +454,8 @@ async def search_vulnerabilities(
     List of collections, aka threats.
   """
   res = await _search_threats_by_collection_type(
-      query, "vulnerability", ctx, limit, order_by)
+      query, "vulnerability", ctx, limit, order_by,
+      extra_excluded_attrs=VULNERABILITY_EXCLUDED_ATTRS)
   return res
 
 
@@ -645,11 +728,16 @@ async def get_collections_commonalities(collection_id: str, ctx: Context) -> str
     Markdown-formatted string with the commonalities of the collection.
   """
   async with vt_client(ctx) as client:
-    data = await client.get_async(f"/collections/{collection_id}?attributes=aggregations")
-    data = await data.json_async()
+    response = await client.get_async(f"/collections/{collection_id}?attributes=aggregations")
+    data = await response.json_async()
+
     sanitized_data = utils.sanitize_response(data["data"])
-    markdown_output = utils.parse_collection_commonalities(sanitized_data)
-  return markdown_output
+    excluded_paths = [
+        f"attributes.aggregations.files.{attr}"
+        for attr in COLLECTION_COMMONALITIES_FILES_EXCLUDED_ATTRS
+    ]
+    sanitized_data = utils.remove_fields(sanitized_data, excluded_paths)
+  return utils.parse_collection_commonalities(sanitized_data)
 
 
 async def _get_yara_rule_details(ctx: Context, rule: dict, rule_type: str) -> typing.Dict[str, typing.Any]:
@@ -707,7 +795,7 @@ async def _get_sigma_rule_details(ctx: Context, rule: dict, rule_type: str) -> t
     return {"error": f"Error fetching Sigma ruleset {ruleset_id}: {e}"}
 
 @server.tool()
-async def get_collection_rules(collection_id: str, ctx: Context, top_n: int = 4, rule_types: typing.List[str] = None) -> typing.Union[typing.List[typing.Dict[str, typing.Any]], typing.Dict[str, str]]:
+async def get_collection_rules(collection_id: str, ctx: Context, top_n: int = 4, rule_types: typing.Optional[typing.List[str]] = None) -> typing.Union[typing.List[typing.Dict[str, typing.Any]], typing.Dict[str, str]]:
   """Retrieve top N community rules and all curated hunting rules for a specific collection.
 
   Note:
@@ -752,7 +840,7 @@ async def get_collection_rules(collection_id: str, ctx: Context, top_n: int = 4,
           # Iterate through different community rule types
           for key, rule_type in rule_keys_map.items():
             rules = files_aggregations.get(key, [])
-            if rule_type not in rule_type and not rules:
+            if rule_type not in rule_types and not rules:
               continue
 
             # Sort rules by count and take the top N

--- a/server/gti/gti_mcp/tools/files.py
+++ b/server/gti/gti_mcp/tools/files.py
@@ -84,6 +84,56 @@ FILE_KEY_RELATIONSHIPS = [
     "associations",
 ]
 
+# Fields excluded (via the `exclude_attributes` API param) from "behaviours"
+# relationship results returned by `get_entities_related_to_a_file`. These
+# are either too verbose/noisy or too large for regular consumption.
+FILE_BEHAVIOUR_EXCLUDED_ATTRS = [
+    "memory_dumps",
+    "processes_terminated",
+    "registry_keys_opened",
+    "files_written",
+    "files_deleted",
+    "files_opened",
+    "files_dropped",
+    "processes_tree",
+    "processes_created",
+    "signature_matches",
+]
+
+# Fields stripped client-side from the response of `get_file_behavior_summary`.
+# The `behaviour_summary` endpoint doesn't support `exclude_attributes` (its
+# fields aren't nested under `attributes`), so these can't be filtered via the
+# API and are removed after the fact instead. They are either too
+# verbose/noisy or too large for regular consumption.
+FILE_BEHAVIOR_SUMMARY_EXCLUDED_ATTRS = [
+    "files_opened",
+    "modules_loaded",
+    "mutexes_created",
+    "mutexes_opened",
+    "processes_terminated",
+    "processes_tree",
+    "registry_keys_opened",
+    "tags",
+    "text_highlighted",
+    "registry_keys_deleted",
+    "signature_matches",
+    "files_written",
+    "memory_dumps",
+    "http_conversations",
+    "files_deleted",
+    "files_copied",
+    "files_dropped",
+    "ids_alerts",
+    "registry_keys_set",
+    "processes_created",
+    "command_executions",
+    "ip_traffic",
+    "attack_techniques",
+    "memory_pattern_urls",
+    "memory_pattern_domains",
+    "processes_injected"
+]
+
 
 @server.tool()
 async def get_file_report(hash: str, ctx: Context) -> typing.Dict[str, typing.Any]:
@@ -109,8 +159,8 @@ async def get_file_report(hash: str, ctx: Context) -> typing.Dict[str, typing.An
 
 @server.tool()
 async def get_entities_related_to_a_file(
-    hash: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10, 
-) -> list[dict[str, typing.Any]]:
+    hash: str, relationship_name: str, descriptors_only: bool, ctx: Context, limit: int = 10,
+) -> typing.Union[typing.List[typing.Dict[str, typing.Any]], typing.Dict[str, str]]:
     """Retrieve entities related to the the given file hash.
 
     The following table shows a summary of available relationships for file objects.
@@ -179,14 +229,17 @@ async def get_entities_related_to_a_file(
             f"Available relationships are: {','.join(FILE_RELATIONSHIPS)}"
         }
 
+    params = {"exclude_attributes": ",".join(FILE_BEHAVIOUR_EXCLUDED_ATTRS)}
     async with vt_client(ctx) as client:
       res = await utils.fetch_object_relationships(
-          client, 
+          client,
           "files",
-          hash, 
+          hash,
           relationships=[relationship_name],
           descriptors_only=descriptors_only,
-          limit=limit)
+          limit=limit,
+          params=params)
+
     return utils.sanitize_response(res.get(relationship_name, []))
 
 
@@ -245,7 +298,8 @@ async def get_file_behavior_summary(hash: str, ctx: Context) -> typing.Dict[str,
       logging.warning(f"Unexpected response format from VirusTotal API: {res}")
       return {"error": f"Unexpected response format from VirusTotal API: {res}"}
 
-  return utils.sanitize_response(res["data"])
+  data = utils.remove_fields(res["data"], FILE_BEHAVIOR_SUMMARY_EXCLUDED_ATTRS)
+  return utils.sanitize_response(data)
 
 
 @server.tool()

--- a/server/gti/gti_mcp/utils.py
+++ b/server/gti/gti_mcp/utils.py
@@ -116,6 +116,36 @@ async def fetch_object_relationships(
   return data
 
 
+def remove_fields(
+    data: typing.Any, field_paths: typing.List[str]
+) -> typing.Any:
+  """Removes the given dotted-path fields from a dict, in place.
+
+  Args:
+    data: The dict to strip fields from (no-op for other types).
+    field_paths: Dotted paths (e.g. "attributes.tags") identifying the
+      fields to remove.
+  Returns:
+    The same object passed in `data`, with the fields removed.
+  """
+  if not isinstance(data, dict) or not field_paths:
+    return data
+
+  for path in field_paths:
+    keys = path.split(".")
+    obj = data
+    for key in keys[:-1]:
+      if isinstance(obj, dict) and key in obj:
+        obj = obj[key]
+      else:
+        obj = None
+        break
+    if isinstance(obj, dict):
+      obj.pop(keys[-1], None)
+
+  return data
+
+
 def sanitize_response(data: typing.Any) -> typing.Any:
   """Removes empty dictionaries and lists recursively from a response."""
   if isinstance(data, dict):

--- a/server/gti/tests/test_tools.py
+++ b/server/gti/tests/test_tools.py
@@ -289,7 +289,7 @@ async def test_get_reports(
                 "data": [{"type": "object", "id": "obj-id", "attributes": {"foo": "foo", "bar": ""}}],
             },
             {"type": "object", "id": "obj-id", "attributes": {"foo": "foo"}},
-        ),   
+        ),
         (
             "get_entities_related_to_an_ip_address",
             {"ip_address": "8.8.8.8", "relationship_name": "associations", "descriptors_only": "True"},
@@ -371,6 +371,84 @@ async def test_get_entities_related(
 @pytest.mark.asyncio(loop_scope="session")
 @pytest.mark.parametrize(
     argnames=[
+        "tool_arguments", "vt_endpoint", "vt_request_params", "vt_object_response", "expected",
+    ],
+    argvalues=[
+        (
+            {
+                "hash": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+                "relationship_name": "behaviours",
+                "descriptors_only": "False",
+            },
+            "/api/v3/files/275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/behaviours",
+            {
+                "exclude_attributes": ",".join(tools.FILE_BEHAVIOUR_EXCLUDED_ATTRS),
+            },
+            {
+                "data": [{
+                    "type": "file-behaviour",
+                    "id": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f_VirusTotal Jujubox",
+                    "attributes": {"sandbox_name": "VirusTotal Jujubox"},
+                }],
+            },
+            {
+                "type": "file-behaviour",
+                "id": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f_VirusTotal Jujubox",
+                "attributes": {"sandbox_name": "VirusTotal Jujubox"},
+            },
+        ),
+    ],
+    indirect=["vt_endpoint", "vt_request_params", "vt_object_response"],
+)
+@pytest.mark.usefixtures("vt_get_object_with_params_mock")
+async def test_get_entities_related_to_a_file_sends_exclude_attributes(
+    vt_get_object_with_params_mock,
+    tool_arguments,
+    expected,
+):
+    """`get_entities_related_to_a_file` must always request `exclude_attributes`
+    for FILE_BEHAVIOUR_EXCLUDED_ATTRS, so the API omits noisy fields instead of
+    fetching and stripping them client-side."""
+
+    async with client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "get_entities_related_to_a_file", arguments=tool_arguments)
+        assert isinstance(result, mcp.types.CallToolResult)
+        assert result.isError == False
+        assert len(result.content) == 1
+        assert isinstance(result.content[0], mcp.types.TextContent)
+        assert json.loads(result.content[0].text) == expected
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_entities_related_to_a_file_invalid_relationship():
+    """An unknown relationship_name must return a clean error dict rather
+    than crash the tool's structured-output validation. The return type is
+    Union[List[Dict], Dict[str, str]] specifically so this error path (which
+    returns a bare dict) is a valid response shape."""
+
+    async with client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "get_entities_related_to_a_file",
+            arguments={
+                "hash": "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+                "relationship_name": "not_a_real_relationship",
+                "descriptors_only": "True",
+            },
+        )
+        assert isinstance(result, mcp.types.CallToolResult)
+        assert result.isError == False
+        assert len(result.content) == 1
+        content = json.loads(result.content[0].text)
+        assert content["error"] == (
+            "Relationship not_a_real_relationship does not exist. "
+            f"Available relationships are: {','.join(tools.FILE_RELATIONSHIPS)}"
+        )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    argnames=[
         "tool_name", "tool_arguments", "vt_endpoint", "vt_object_response", "expected",
     ],
     argvalues=[
@@ -382,7 +460,20 @@ async def test_get_entities_related(
                 "data": {"type": "object", "id": "obj-id", "attributes": {"foo": "foo", "bar": ""}},
             },
             {"type": "object", "id": "obj-id", "attributes": {"foo": "foo"}}
-        ), 
+        ),
+        (
+            "get_file_behavior_summary",
+            {"hash": "375a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f"},
+            "/api/v3/files/375a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f/behaviour_summary",
+            {
+                "data": {
+                    "calls_highlighted": ["GetTickCount"],
+                    "tags": ["evil"],
+                    "files_opened": ["C:\\evil.txt"],
+                },
+            },
+            {"calls_highlighted": ["GetTickCount"]}
+        ),
         (
             "get_collection_timeline_events",
             {"id": "collection_id"},
@@ -629,10 +720,12 @@ async def test_get_simple_tools(
             {"query": "APT44"},
             "/api/v3/collections",
             {
-                "filter": "collection_type:vulnerability APT44", 
+                "filter": "collection_type:vulnerability APT44",
                 "order": "relevance-",
                 "relationships": ",".join(tools.COLLECTION_KEY_RELATIONSHIPS),
-                "exclude_attributes": tools.COLLECTION_EXCLUDED_ATTRS,
+                "exclude_attributes": ",".join(
+                    [tools.COLLECTION_EXCLUDED_ATTRS, *tools.VULNERABILITY_EXCLUDED_ATTRS]
+                ),
             },
             {
                 "data": [{
@@ -775,6 +868,14 @@ async def test_get_collection_feature_matches(
                                         "total_related": 1,
                                         "prevalence": 1.0
                                     }
+                                ],
+                                "first_submission_dates": [
+                                    {
+                                        "value": "2024-01-01",
+                                        "count": 5,
+                                        "total_related": 5,
+                                        "prevalence": 1.0
+                                    }
                                 ]
                             }
                         }
@@ -784,8 +885,8 @@ async def test_get_collection_feature_matches(
             (
                 "# Commonalities for 67869ffd5a02cfc31584dfcf9b7516e7f443cbd1d8cfae4436b5cc38c9fdecf6\n\n"
                 "## files commonalities\n\n"
-                "### itw urls\n"
-                "- 1 matches of https://pcsdl.com/short-url-v2/000585065547/scenario/f91705e56983ba3c3cd940d62bc2ed35___158e5ef2-6f0f-46fd-b1b7-feaa02550432.vbs?protocol=https with a prevalence of 1\n\n"
+                "### first submission dates\n"
+                "- 5 matches of 2024-01-01 with a prevalence of 1\n\n"
             )
         ),
     ],
@@ -810,6 +911,42 @@ async def test_get_collections_commonalities(
         assert isinstance(result.content[0], mcp.types.TextContent)
         assert isinstance(result.content[0].text, str)
         assert result.content[0].text == expected
+
+
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    argnames=[
+        "tool_arguments", "vt_endpoint", "vt_request_params", "vt_object_response",
+    ],
+    argvalues=[
+        (
+            {"collection_id": "does-not-exist"},
+            "/api/v3/collections/does-not-exist",
+            {"attributes": "aggregations"},
+            {"error": {"code": "NotFoundError", "message": "Collection \"does-not-exist\" not found"}},
+        ),
+    ],
+    indirect=["vt_endpoint", "vt_request_params", "vt_object_response"],
+)
+@pytest.mark.usefixtures("vt_get_object_with_params_mock")
+async def test_get_collections_commonalities_api_error(
+    vt_get_object_with_params_mock,
+    tool_arguments,
+):
+    """Current behavior: when the API response has no 'data' key (e.g. an
+    invalid/nonexistent collection_id), `get_collections_commonalities`
+    crashes with a raw KeyError surfaced as a tool execution error, since it
+    indexes `data["data"]` without checking for the key first."""
+
+    async with client_session(server._mcp_server) as client:
+        result = await client.call_tool(
+            "get_collections_commonalities", arguments=tool_arguments)
+        assert isinstance(result, mcp.types.CallToolResult)
+        assert result.isError == True
+        assert len(result.content) == 1
+        assert result.content[0].text == (
+            "Error executing tool get_collections_commonalities: 'data'"
+        )
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -1396,7 +1533,38 @@ async def test_get_collection_rules_partial_error():
     mock_client_instance.get_async.side_effect = mock_get_async
     mock_vt_client = MagicMock()
     mock_vt_client.__aenter__.return_value = mock_client_instance
-    
+
     with patch("gti_mcp.tools.collections.vt_client", return_value=mock_vt_client):
         result = await collections.get_collection_rules(collection_id="test_id", ctx=mock_ctx)
     assert result == []
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_collection_rules_explicit_null_rule_types():
+    """Calling `get_collection_rules` over the real MCP protocol with an
+    explicit `rule_types: null` must not fail schema validation. The
+    parameter is typed `Optional[List[str]]` specifically to allow this --
+    a plain `List[str] = None` annotation accepts an omitted/defaulted field
+    but rejects an explicit null with a pydantic validation error."""
+    mock_client_instance = AsyncMock()
+
+    async def mock_get_async(url, **kwargs):
+        mock_resp = MagicMock()
+        async def json_async():
+            return {"data": {"attributes": {"aggregations": {"files": {}}}}}
+        mock_resp.json_async = json_async
+        return mock_resp
+
+    mock_client_instance.get_async.side_effect = mock_get_async
+    mock_vt_client = MagicMock()
+    mock_vt_client.__aenter__.return_value = mock_client_instance
+
+    with patch("gti_mcp.tools.collections.vt_client", return_value=mock_vt_client):
+        async with client_session(server._mcp_server) as client:
+            result = await client.call_tool(
+                "get_collection_rules",
+                arguments={"collection_id": "test_id", "top_n": 4, "rule_types": None},
+            )
+            assert isinstance(result, mcp.types.CallToolResult)
+            assert not result.isError
+            assert result.structuredContent == {"result": []}


### PR DESCRIPTION
## Summary

Several GTI MCP tools return large, noisy response payloads that bloat context and crowd out the fields that actually matter for analysis. This PR trims known-noisy/verbose fields from four tool responses — either via the VirusTotal API's `exclude_attributes` param (cheaper, filtered server-side) or a new `utils.remove_fields` helper for endpoints where that param isn't supported or doesn't reach nested sub-fields.

Also included: a `rule_type`/`rule_types` comparison bug fix in `get_collection_rules`, and loosening its `rule_types` param to `Optional[List[str]]` so an explicit `null` validates correctly over the MCP protocol.

## Changes

### Excluded fields by tool

| Tool | Fields removed |
|---|---|
| `get_entities_related_to_a_file` (relationship `behaviours`) | `memory_dumps`, `processes_terminated`, `registry_keys_opened`, `files_written`, `files_deleted`, `files_opened`, `files_dropped`, `processes_tree`, `processes_created`, `signature_matches` |
| `get_file_behavior_summary` | `files_opened`, `modules_loaded`, `mutexes_created`, `mutexes_opened`, `processes_terminated`, `processes_tree`, `registry_keys_opened`, `tags`, `text_highlighted`, `registry_keys_deleted`, `signature_matches`, `files_written`, `memory_dumps`, `http_conversations`, `files_deleted`, `files_copied`, `files_dropped`, `ids_alerts`, `registry_keys_set`, `processes_created`, `command_executions`, `ip_traffic`, `attack_techniques`, `memory_pattern_urls`, `memory_pattern_domains`, `processes_injected` |
| `get_collections_commonalities` | `attributes.aggregations.files.{itw_urls, execution_parents, compressed_parents, pcap_parents, dropped_files_sha256, email_parents, tags, main_icon_dhash, main_icon_raw_md5, vhash, imphash, behash, tlshhash, attributions, crowdsourced_ids_results, crowdsourced_yara_results, embedded_domains, embedded_ips, mutexes_created, mutexes_opened, registry_keys_deleted, registry_keys_opened, registry_keys_set, file_types, crowdsourced_sigma_results, debug_codeview_guids, debug_codeview_names, debug_timestamps, dropped_files_path, exiftool_authors, exiftool_create_dates, exiftool_creators, exiftool_last_printed, exiftool_producers, exiftool_subjects, exiftool_titles, filecondis_dhash, netassembly_mvid, office_application_names, office_authors, office_creation_datetimes, office_last_saved, pe_info_imports, pe_info_exports, pe_info_section_md5, pe_info_section_names, sandbox_verdicts, memory_pattern_urls, embedded_urls, parent_contacted_domains}` |
| `search_vulnerabilities` | `cpes`, `vendor_fix_references`, `sources`, `version_history`, `field_sources`, `tags_details`, `alt_names_details` |

### Supporting changes

- **`utils.py`**: added `remove_fields(data, field_paths)` — removes dotted-path fields (e.g. `attributes.aggregations.files.tags`) from a response dict in place, for endpoints where the API's `exclude_attributes` can't reach nested sub-fields or isn't supported at all.
- **`collections.py`**: `_search_threats_by_collection_type` now accepts an optional `extra_excluded_attrs` list, used by `search_vulnerabilities` to layer `VULNERABILITY_EXCLUDED_ATTRS` on top of the shared `COLLECTION_EXCLUDED_ATTRS`.
- **`collections.py`**: fixed `get_collection_rules` filtering the wrong loop variable (`rule_type not in rule_type` → `rule_type not in rule_types`), and widened `rule_types` to `Optional[List[str]]`.

## Test plan

- [x] Added parametrized test asserting `get_entities_related_to_a_file` sends `exclude_attributes=FILE_BEHAVIOUR_EXCLUDED_ATTRS` for the `behaviours` relationship.
- [x] Added test asserting `get_file_behavior_summary` strips `FILE_BEHAVIOR_SUMMARY_EXCLUDED_ATTRS` from the response.
- [x] Updated `get_collections_commonalities` fixture/expected output to reflect stripped fields.
- [x] Added test for `get_collections_commonalities` error path when the API response has no `data` key.
- [x] Added test asserting `search_vulnerabilities` sends the combined `exclude_attributes` list.
- [x] Added test covering `get_collection_rules` with an invalid `relationship_name` and with explicit `rule_types: null`.
- [x] Run full test suite (`pytest server/gti/tests/test_tools.py`) locally before merge.
