### PR TITLE
fix(secops): include entity values in related entities formatter

### DIFF
--- a/server/secops/secops_mcp/tools/entity_lookup.py
+++ b/server/secops/secops_mcp/tools/entity_lookup.py
@@ -138,10 +138,13 @@ async def lookup_entity(
             result += f'Related Entities ({len(related_entities)}):\n'
             for i, entity in enumerate(related_entities[:5], 1):  # Limit to 5 related entities
                 entity_type = 'Unknown'
+                entity_value = 'Unknown'
                 if hasattr(entity, 'metadata') and hasattr(entity.metadata, 'entity_type'):
                     entity_type = entity.metadata.entity_type
+                if hasattr(entity, 'value'):
+                    entity_value = entity.value
 
-                result += f'{i}. Type: {entity_type}\n'
+                result += f'{i}. Value: {entity_value}, Type: {entity_type}\n'
 
             if len(related_entities) > 5:
                 result += f'... and {len(related_entities) - 5} more related entities\n'


### PR DESCRIPTION
Fixes #268

## Problem
The lookup_entity formatter was only displaying the entity type for related entities, omitting the actual entity values (IPs, domains, hashes, etc.).

## Solution
Added extraction and display of entity.value alongside entity type for related entities, providing complete information about related entities in the summary.

## Changes
- Initialize entity_value default to 'Unknown'
- Extract entity.value attribute if available
- Update output format to include both value and type

## Verification
- Python syntax check: ✓ Passed
- Code review: ✓ No issues found
- Minimal change focused on bug fix