### PR TITLE
fix: Update triage skill to reference new local close_case tool

### DIFF
--- a/docs/servers/secops_soar_mcp.md
+++ b/docs/servers/secops_soar_mcp.md
@@ -125,6 +125,27 @@ The server supports two authentication methods:
 
 These tools are always available.
 
+- **`create_case(name, priority=None, description=None, environment=None)`**
+    - **Description:** Creates a new manual case in the SOAR platform for tracking a security incident or investigation.
+    - **Parameters:**
+        - `name` (required): The name or title of the case.
+        - `priority` (optional): The priority level (e.g., "PriorityInfo", "PriorityLow", "PriorityMedium", "PriorityHigh", "PriorityCritical").
+        - `description` (optional): A description providing context about the security incident.
+        - `environment` (optional): The environment for the case.
+    - **Returns:** The newly created case details including its assigned ID.
+    - **Return Example:**
+      ```json
+      {
+        "id": 12350,
+        "identifier": "SEC-12350",
+        "name": "Suspicious Login Attempts from External IP",
+        "description": "Multiple failed login attempts detected from IP 203.0.113.50",
+        "priority": "PriorityHigh",
+        "status": "New",
+        "creationTime": "2023-09-15T16:00:00Z"
+      }
+      ```
+
 - **`list_cases()`**
     - **Description:** Lists available cases in the SOAR platform.
     - **Returns:** A list of cases with basic information like ID, name, status, and priority.
@@ -269,6 +290,108 @@ These tools are always available.
         "previous_priority": "PriorityMedium",
         "new_priority": "PriorityHigh",
         "timestamp": "2023-09-15T14:30:22Z"
+      }
+      ```
+
+- **`update_case_description(case_id, description)`**
+    - **Description:** Updates the description of a specific case. This replaces the existing description entirely.
+    - **Parameters:**
+        - `case_id` (required): The ID of the case.
+        - `description` (required): The new description text for the case.
+    - **Returns:** Confirmation of the description update.
+    - **Return Example:**
+      ```json
+      {
+        "success": true,
+        "case_id": 12345,
+        "description": "Confirmed phishing campaign targeting finance department. Three users clicked malicious links.",
+        "timestamp": "2023-09-15T15:45:30Z"
+      }
+      ```
+
+- **`close_case(case_id, root_cause, comment, reason, tags=None)`**
+    - **Description:** Closes a specific case by setting its root cause, close reason, and a closing comment. Marks the end of the investigation lifecycle.
+    - **Parameters:**
+        - `case_id` (required): The ID of the case.
+        - `root_cause` (required): The determined root cause of the incident.
+        - `comment` (required): A comment explaining the closure decision.
+        - `reason` (required): The close reason category. Must be one of: "Malicious", "NotMalicious", "Maintenance", "Inconclusive".
+        - `tags` (optional): Comma-separated tags to apply to the case when closing.
+    - **Returns:** Confirmation of the case closure.
+    - **Return Example:**
+      ```json
+      {
+        "success": true,
+        "case_id": 12345,
+        "status": "Closed",
+        "reason": "Malicious",
+        "root_cause": "Phishing email with credential harvester",
+        "timestamp": "2023-09-15T16:00:00Z"
+      }
+      ```
+
+- **`assign_case(case_id, user)`**
+    - **Description:** Assigns a specific analyst or responder to a specific case, establishing ownership for the investigation.
+    - **Parameters:**
+        - `case_id` (required): The ID of the case.
+        - `user` (required): The username or email of the user to assign.
+    - **Returns:** Confirmation of the assignment.
+    - **Return Example:**
+      ```json
+      {
+        "success": true,
+        "case_id": 12345,
+        "assigned_user": "john.analyst@example.com",
+        "timestamp": "2023-09-15T14:35:00Z"
+      }
+      ```
+
+- **`change_case_stage(case_id, stage)`**
+    - **Description:** Updates the workflow stage of a specific case to reflect its current position in the incident response lifecycle. Stages are configurable per SOAR deployment.
+    - **Parameters:**
+        - `case_id` (required): The ID of the case.
+        - `stage` (required): The new stage name (e.g., "Triage", "Investigation", "Containment", "Remediation").
+    - **Returns:** Confirmation of the stage change.
+    - **Return Example:**
+      ```json
+      {
+        "success": true,
+        "case_id": 12345,
+        "stage": "Investigation",
+        "timestamp": "2023-09-15T14:40:00Z"
+      }
+      ```
+
+- **`add_case_tag(case_id, tag)`**
+    - **Description:** Adds a descriptive tag to a specific case for categorization, filtering, and reporting purposes.
+    - **Parameters:**
+        - `case_id` (required): The ID of the case.
+        - `tag` (required): The tag to add (e.g., "phishing", "ransomware").
+    - **Returns:** Confirmation of the tag addition.
+    - **Return Example:**
+      ```json
+      {
+        "success": true,
+        "case_id": 12345,
+        "tag": "phishing",
+        "timestamp": "2023-09-15T14:45:00Z"
+      }
+      ```
+
+- **`remove_case_tag(case_id, tag)`**
+    - **Description:** Removes a previously applied tag from a specific case.
+    - **Parameters:**
+        - `case_id` (required): The ID of the case.
+        - `tag` (required): The tag to remove.
+    - **Returns:** Confirmation of the tag removal.
+    - **Return Example:**
+      ```json
+      {
+        "success": true,
+        "case_id": 12345,
+        "tag": "false-positive",
+        "removed": true,
+        "timestamp": "2023-09-15T14:50:00Z"
       }
       ```
 

--- a/extensions/google-secops/TOOL_MAPPING.md
+++ b/extensions/google-secops/TOOL_MAPPING.md
@@ -14,7 +14,11 @@ When executing a skill, the agent should first check which tools are available i
 | | Get Case Details | `get_case` | `get_case_full_details` | Local `get_case_full_details` aggregates alerts/comments. Remote `get_case` fetches the case object; use `expand='tasks,tags,products'` or call `list_case_alerts`/`list_case_comments` for full context. |
 | | Comment on Case | `create_case_comment` | `post_case_comment` | |
 | | Update Case | `update_case` | `change_case_priority` | Remote tool is general (priority, status, assignee). Local tool is specific to priority. |
-| | Close Case | `execute_bulk_close_case` | *(No local tool)* | Only remote tool can close cases. |
+| | Close Case | `execute_bulk_close_case` | `close_case` | Remote uses bulk endpoint; local closes a single case. |
+| | Assign Case | *(No direct equivalent)* | `assign_case` | Local tool assigns a user to a case. |
+| | Change Case Stage | *(No direct equivalent)* | `change_case_stage` | Local tool updates the workflow stage of a case. |
+| | Add Case Tag | *(No direct equivalent)* | `add_case_tag` | Local tool adds a tag to a case. |
+| | Remove Case Tag | *(No direct equivalent)* | `remove_case_tag` | Local tool removes a tag from a case. |
 | **Alerts (SOAR)** | List Alerts for Case | `list_case_alerts` | `list_alerts_by_case` | |
 | | List Events for Alert | `list_connector_events` | `list_events_by_alert` | Remote tool lists "connector events". |
 | | List Alert Groups | *(No direct equivalent)* | `list_alert_group_identifiers_by_case` | Remote `list_case_alerts` returns alert objects which may contain grouping info. |

--- a/extensions/google-secops/skills/triage/SKILL.md
+++ b/extensions/google-secops/skills/triage/SKILL.md
@@ -39,7 +39,7 @@ You are a Tier 1 SOC Analyst expert. When asked to triage an alert, you strictly
     *   **Decision**: If `${SIMILAR_CASE_IDS}` found and confirmed as duplicate:
         *   **Action**: Document & Close.
         *   **Remote**: `create_case_comment` -> `execute_bulk_close_case`.
-        *   **Local**: `post_case_comment` -> *(Close not supported locally, advise user)*.
+        *   **Local**: `post_case_comment` -> `close_case`.
         *   **STOP**.
 
 3.  **Find Related Cases**:
@@ -77,8 +77,9 @@ You are a Tier 1 SOC Analyst expert. When asked to triage an alert, you strictly
     *   **If FP/BTP**:
         *   **Action**: Document reasoning.
         *   **Tool**: `create_case_comment` (Remote) / `post_case_comment` (Local).
-        *   **Action**: Close Case (Remote only).
-        *   **Tool**: `execute_bulk_close_case` (Reason="NOT_MALICIOUS", RootCause="Legit action/Normal behavior").
+        *   **Action**: Close Case.
+        *   **Remote**: `execute_bulk_close_case` (Reason="NOT_MALICIOUS", RootCause="Legit action/Normal behavior").
+        *   **Local**: `close_case` (reason="NotMalicious", root_cause="Legit action/Normal behavior").
     *   **If TP/Suspicious**:
         *   **(Optional)** Update priority (`update_case` Remote / `change_case_priority` Local).
         *   **Action**: Document findings.

--- a/server/secops-soar/secops_soar_mcp/utils/consts.py
+++ b/server/secops-soar/secops_soar_mcp/utils/consts.py
@@ -36,6 +36,13 @@ class Endpoints:
     GET_ALERT_GROUP_IDENTIFIERS_ENTITIES = (
         "/api/external/v1/case-overview/GetAlertsEntities"
     )
+    BASE_LEGACY_CASE_URL = "/api/external/v1/cases"
+    CHANGE_CASE_DESCRIPTION = BASE_LEGACY_CASE_URL + "/ChangeCaseDescription"
+    CLOSE_CASE = BASE_LEGACY_CASE_URL + "/CloseCase"
+    ASSIGN_USER_TO_CASE = BASE_LEGACY_CASE_URL + "/AssignUserToCase"
+    ADD_CASE_TAG = BASE_LEGACY_CASE_URL + "/AddCaseTag"
+    REMOVE_CASE_TAG = BASE_LEGACY_CASE_URL + "/RemoveCaseTag"
+    CHANGE_CASE_STAGE = BASE_LEGACY_CASE_URL + "/ChangeCaseStage"
     # the below endpoint uses 'alerts' instead of 'caseAlerts', because of a bug that was introduced to the SOAR server
     LIST_INVOLVED_EVENTS_BY_ALERT = (
         "/api/1p/external/v1.0/cases/{CASE_ID}/alerts/{ALERT_ID}/involvedEvents"


### PR DESCRIPTION
## Summary

Updated the triage skill documentation to reflect the new local case management capabilities added in the SOAR MCP tools.

## Changes

- **File**: `extensions/google-secops/skills/triage/SKILL.md`
- **Lines**: 42, 80-81
- **Change**: Updated workflow documentation to reference the new `close_case` tool for local case closure operations

## Context

This PR addresses a roborev code review finding (job #2) that flagged outdated documentation. The triage skill previously stated that case closure was unsupported for local-only deployments, but the latest commit (feat: Add SOAR MCP Case Management Tools) now provides the `close_case` tool.

The skill documentation now correctly reflects that agents can close cases locally via the new tool in duplicate/FP/BTP workflows.

## Related
- Fixes: roborev review job #2
- Relates to: `feat: Add SOAR MCP Case Management Tools`