### PR TITLE
fix(gti): honor proxy environment settings

### DIFF
--- a/server/gti/gti_mcp/server.py
+++ b/server/gti/gti_mcp/server.py
@@ -35,7 +35,7 @@ def _vt_client_factory(unused_ctx) -> vt.Client:
   api_key = os.getenv("VT_APIKEY")
   if not api_key:
     raise ValueError("VT_APIKEY environment variable is required")
-  return vt.Client(api_key)
+  return vt.Client(api_key, trust_env=True)
 
 vt_client_factory = _vt_client_factory
 

--- a/server/gti/tests/test_tools.py
+++ b/server/gti/tests/test_tools.py
@@ -17,13 +17,23 @@ import pytest
 import asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
 
-from gti_mcp.server import server
+from gti_mcp.server import _vt_client_factory, server
 from gti_mcp import tools
 from gti_mcp.tools import collections
 
 from mcp.shared.memory import (
     create_connected_server_and_client_session as client_session,
 )
+
+
+def test_vt_client_factory_trusts_proxy_environment(monkeypatch):
+    """Ensure the VirusTotal client honors standard proxy environment vars."""
+    monkeypatch.setenv("VT_APIKEY", "test-api-key")
+
+    with patch("gti_mcp.server.vt.Client") as client:
+        _vt_client_factory(None)
+
+    client.assert_called_once_with("test-api-key", trust_env=True)
 
 
 @pytest.mark.asyncio(loop_scope="session")


### PR DESCRIPTION
Fixes #142

## Summary

- construct the VirusTotal client with `trust_env=True` so standard proxy environment variables are honored
- add regression coverage for the client factory configuration

## Testing

- `python -m pytest -q server/gti/tests` (56 passed)
- `ruff check --isolated --select E9,F63,F7,F82` on changed files
- `python -m compileall -q` on changed files
