### PR TITLE
chore: bump package versions and pin mcp<2.0 across all servers

### DIFF
--- a/server/gti/pyproject.toml
+++ b/server/gti/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gti-mcp"
-version = "0.1.2"
+version = "0.1.3"
 description = "Google Threat Intelligence MCP server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server/gti/setup.py
+++ b/server/gti/setup.py
@@ -19,7 +19,7 @@ setup = setuptools.setup
 
 setup(
     name="gti-mcp",
-    version="0.1.2",
+    version="0.1.3",
     packages=setuptools.find_packages(),
     install_requires=[
         "mcp>=1.23.0,<2.0",

--- a/server/scc/pyproject.toml
+++ b/server/scc/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scc-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "Security Command Center MCP server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "mcp[cli]>=1.4.1",
+    "mcp[cli]>=1.4.1,<2.0",
     "python-dotenv>=1.0.0",
     "typing-extensions>=4.8.0",
     "aiohttp>=3.9.0",

--- a/server/scc/setup.py
+++ b/server/scc/setup.py
@@ -18,10 +18,10 @@ setup = setuptools.setup
 
 setup(
     name="scc-mcp",
-    version="0.1.0",
+    version="0.1.1",
     py_modules=["scc_mcp", "main"],
     install_requires=[
-        "mcp",
+        "mcp[cli]>=1.4.1,<2.0",
         "google-cloud-securitycenter",
         "google-cloud-asset",
     ],

--- a/server/secops-soar/pyproject.toml
+++ b/server/secops-soar/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "secops-soar-mcp"
-version = "0.1.1"
+version = "0.1.2"
 description = "Google SecOps SOAR MCP server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "aiohttp>=3.11.15",
-    "mcp[cli]>=1.4.1"
+    "mcp[cli]>=1.4.1,<2.0"
 ]
 
 [project.urls]

--- a/server/secops-soar/setup.py
+++ b/server/secops-soar/setup.py
@@ -19,8 +19,12 @@ setup = setuptools.setup
 
 setup(
     name="secops-soar-mcp",
-    version="0.1.0",
+    version="0.1.2",
     packages=setuptools.find_packages(),
+    install_requires=[
+        "aiohttp>=3.11.15",
+        "mcp[cli]>=1.4.1,<2.0",
+    ],
     entry_points={
         "console_scripts": [
             "secops-soar-mcp=secops_soar_mcp.server:main",

--- a/server/secops/pyproject.toml
+++ b/server/secops/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "google-secops-mcp"
-version = "0.7.0"
+version = "0.7.1"
 description = "Google SecOps MCP server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     "httpx>=0.28.1",
-    "mcp[cli]>=1.26.0",
+    "mcp[cli]>=1.26.0,<2.0",
     "secops>=0.35.1",
     "google-auth>=2.48.0",
     "google-auth-httplib2>=0.3.0",

--- a/server/secops/secops_mcp/server.py
+++ b/server/secops/secops_mcp/server.py
@@ -32,7 +32,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('secops-mcp')
 
 # Constants
-USER_AGENT = 'secops-app/0.7.0'
+USER_AGENT = 'secops-app/0.7.1'
 
 # Default Chronicle configuration from environment variables
 DEFAULT_PROJECT_ID = os.environ.get('CHRONICLE_PROJECT_ID', '725716774503')

--- a/server/secops/setup.py
+++ b/server/secops/setup.py
@@ -19,11 +19,15 @@ setup = setuptools.setup
 
 setup(
     name="google-secops-mcp",
-    version="0.7.0",
+    version="0.7.1",
     py_modules=["secops_mcp", "main"],  # Include both modules
     install_requires=[
-        "fastmcp",
-        "secops",
+        "httpx>=0.28.1",
+        "mcp[cli]>=1.26.0,<2.0",
+        "secops>=0.35.1",
+        "google-auth>=2.48.0",
+        "google-auth-httplib2>=0.3.0",
+        "google-api-python-client>=2.190.0",
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary

Bump package versions and cap `mcp` / `mcp[cli]` dependency constraints below `<2.0` across all server packages to prevent breaking changes from `mcp` 2.x releases. Also add root `GEMINI.md` and `AGENTS.md` with repository guidelines for coding agents.

## Changes

- **`google-secops-mcp`**:
  - Bump version to `0.7.1` in `server/secops/pyproject.toml` and `server/secops/setup.py`
  - Bump `USER_AGENT` to `secops-app/0.7.1` in `server/secops/secops_mcp/server.py`
  - Pin `mcp[cli]>=1.26.0,<2.0`
  - Align `setup.py` `install_requires` with `pyproject.toml`
- **`gti-mcp`**:
  - Bump version to `0.1.3` in `server/gti/pyproject.toml` and `server/gti/setup.py`
- **`secops-soar-mcp`**:
  - Bump version to `0.1.2` in `server/secops-soar/pyproject.toml` and `server/secops-soar/setup.py`
  - Pin `mcp[cli]>=1.4.1,<2.0`
- **`scc-mcp`**:
  - Bump version to `0.1.1` in `server/scc/pyproject.toml` and `server/scc/setup.py`
  - Pin `mcp[cli]>=1.4.1,<2.0`
- **Agent Guidelines**:
  - Add root `GEMINI.md` and `AGENTS.md` specifying synchronized version bump rules, `mcp<2.0` constraints, and verification procedures.

## Verification

- **Unit tests**:
  - `server/gti`: 55/55 passed (`pytest`)
  - `server/secops`: 16/16 unit tests passed
- **Protocol Handshake & Tool Discovery**:
  - Verified MCP protocol initialization and tool listing across all 4 servers via connected client sessions.
- **End-to-End Live Invocations**:
  - `google-secops-mcp`: Tested live calls (`list_curated_rule_sets`, `list_security_rules`, `list_watchlists`) against Chronicle tenant.
  - `secops-soar-mcp`: Tested live tool calls (`list_cases`) against active SOAR instance with scope discovery.
  - `gti-mcp`: Tested live tool calls (`search_threat_actors`, `search_vulnerabilities`) against Google Threat Intelligence API.
  - `scc-mcp`: Tested live tool calls (`top_vulnerability_findings`) against GCP Security Command Center API.