### PR TITLE
Add Antigravity (agy) subagent management system via tmux

### DIFF
--- a/.agents/skills/subagent/SKILL.md
+++ b/.agents/skills/subagent/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: subagent
+description: Use when running, coordinating, monitoring, or managing parallel Antigravity (agy) subagent tasks in detached tmux sessions or split panes
+---
+
+# Antigravity (agy) Subagent Manager
+
+Orchestrates multiple parallel Antigravity (`agy`) CLI instances using `tmux` sessions. Subagents persist across exits, run background tasks or independent research, and can be queried or controlled asynchronously.
+
+## Quick Reference
+
+| Command | Action | Key Flags / Usage |
+| :--- | :--- | :--- |
+| `spawn` | Launch new subagent session | `--name=<name> --prompt="<prompt>" [--model=<model>]` |
+| `spawn-split` | Launch subagent in split pane | `--name=<name> --prompt="<prompt>" [--vertical=true] [--size=50]` |
+| `send` | Send prompt or command to subagent | `--name=<name> --message="<msg>"` |
+| `get-output` | Retrieve output from subagent | `--name=<name> [--lines=50] [--all=true]` |
+| `status` | Check session health, PID, and output | `--name=<name>` |
+| `list` | List active subagent sessions | `[--format=detailed]` |
+| `broadcast` | Send message to multiple subagents | `--names="agent1,agent2" --message="<msg>"` |
+| `attach` | View interactive session | `tmux attach-session -t <name>` |
+| `kill` | Terminate subagent session | `--name=<name>` |
+
+---
+
+## Subcommand Workflows
+
+### 1. `spawn`
+Starts a detached tmux session running `bash`, launches `agy`, waits for initialization, and submits the initial prompt.
+
+```bash
+# 1. Create detached tmux session
+tmux new-session -d -s "<name>" bash
+
+# 2. Launch agy in session
+tmux send-keys -t "<name>" "agy" C-m
+
+# 3. Wait for agy startup sequence (banner, tips, model connection)
+sleep 5
+
+# 4. Submit prompt (agy submits on single Enter)
+tmux send-keys -t "<name>" -l "<prompt>"
+tmux send-keys -t "<name>" C-m
+
+# 5. Confirm session is alive
+tmux list-sessions | grep "<name>"
+```
+
+*(If `--model` is specified, launch `agy --model <model>`)*
+
+### 2. `spawn-split`
+Spawns a subagent inside a split pane in the current tmux window using non-interactive print mode (`agy -p`).
+
+```bash
+# Horizontal (default) or Vertical (-h) split
+tmux split-window -v -p 50 "agy -p '<prompt>'"
+
+# Tag pane for identification
+tmux select-pane -T "<name>"
+```
+
+### 3. `send`
+Sends a prompt, shell command, or slash command to a running subagent session.
+
+```bash
+# For shell commands starting with '!':
+tmux send-keys -t "<name>" "<command>" C-m
+
+# For regular text prompts or slash commands:
+tmux send-keys -t "<name>" -l "<message>"
+tmux send-keys -t "<name>" C-m
+```
+
+### 4. `get-output`
+Captures text lines from the target session's scrollback buffer.
+
+```bash
+# Last N lines (default 50):
+tmux capture-pane -t "<name>" -p -S -50
+
+# Entire available buffer:
+tmux capture-pane -t "<name>" -p -S -
+```
+
+### 5. `status`
+Inspects session existence, pane PID, running command, and recent output snippet.
+
+```bash
+# Verify session exists
+tmux has-session -t "<name>" 2>/dev/null && echo "✓ Session '<name>' exists" || echo "✗ Session '<name>' not found"
+
+# Show session details
+tmux list-sessions -F "#{session_name}: #{session_windows} windows, created #{session_created_string}" | grep "<name>"
+
+# Show running process & PID
+tmux list-panes -t "<name>" -F "Pane: #{pane_current_command} (PID: #{pane_pid})" 2>/dev/null
+
+# Capture last 10 lines
+tmux capture-pane -t "<name>" -p -S -10 2>/dev/null
+```
+
+### 6. `list`
+Lists active tmux sessions.
+
+```bash
+# Simple
+tmux list-sessions 2>/dev/null || echo "No active subagents"
+
+# Detailed
+tmux list-sessions -F "Session: #{session_name} | Created: #{session_created_string} | Windows: #{session_windows} | Attached: #{session_attached}" 2>/dev/null
+```
+
+### 7. `broadcast`
+Iterates over a comma-separated list of session names and sends the message to each.
+
+```bash
+for session in $(echo "<names>" | tr "," "\n"); do
+  tmux send-keys -t "$session" -l "<message>" 2>/dev/null && tmux send-keys -t "$session" C-m 2>/dev/null && echo "Sent to $session" || echo "Failed to send to $session"
+done
+```
+
+### 8. `attach`
+Attach to view and interact with the session directly in your terminal:
+
+```bash
+tmux attach-session -t "<name>"
+```
+> **Detach Shortcut**: Press `Ctrl+B`, then `D` to detach and return to your parent terminal.
+
+### 9. `kill`
+Terminates the specified tmux session.
+
+```bash
+tmux kill-session -t "<name>" && echo "Subagent '<name>' terminated"
+```
+
+---
+
+## Tips & Operational Notes
+- Subagents run as persistent processes; always terminate unused sessions with `kill` to release system resources.
+- In Antigravity CLI (`agy`), a single Enter (`C-m`) submits prompts. Do not send double Enter (`C-m C-m`).
+- Use `-l` with `tmux send-keys` when sending prompt text to prevent tmux from interpreting special characters or key bindings.

--- a/.gemini/commands/subagent.toml
+++ b/.gemini/commands/subagent.toml
@@ -1,0 +1,563 @@
+description = "Manage Antigravity (agy) subagents using tmux sessions for parallel task execution"
+prompt = """
+You are managing Antigravity (agy) subagents through tmux sessions. This allows running multiple agy instances
+in parallel for complex workflows, research tasks, and multi-agent coordination.
+"""
+
+# Spawn a new subagent in a tmux session
+[[subCommands]]
+name = "spawn"
+description = "Start a new Antigravity (agy) subagent in a tmux session"
+prompt = """
+{% if help %}
+Usage: /subagent spawn [OPTIONS]
+
+Start a new Antigravity (agy) subagent in a tmux session.
+
+Options:
+  --name      Name for the tmux session (required)
+  --prompt    Initial prompt for the subagent (required)
+  --model     Model to use (optional, defaults to current model)
+  --detached  Run in detached mode (optional, default: true)
+  --help      Show this help message
+
+Examples:
+  /subagent spawn --name=researcher --prompt="Research security vulnerabilities"
+  /subagent spawn --name=coder --prompt="Write Python scripts" --model=opus
+  /subagent spawn --name=analyst --prompt="Analyze the following data..."
+  /subagent spawn --name=monitor --prompt="! watch -n 5 'ps aux | head'"
+
+The subagent will:
+- Run in its own tmux session
+- Persist even if the main agy instance exits
+- Be accessible for sending commands and retrieving output
+- Continue running until explicitly killed
+
+Use Cases:
+- Parallel research on different topics
+- Running long-running analysis tasks
+- Coordinating multiple specialized agents
+- Background monitoring and alerting
+{% else %}
+Execute the following commands to spawn a new subagent:
+```bash
+# Create new tmux session with bash shell
+! tmux new-session -d -s "{{name}}" bash
+```
+```bash
+# Launch agy in that session
+! tmux send-keys -t "{{name}}" "agy{% if model %} --model {{model}}{% endif %}" C-m
+```
+```bash
+# Wait for agy to fully initialize (banner, tips, etc.)
+! sleep 5
+```
+```bash
+# Send initial prompt (check if it's a command or regular text)
+{% if prompt.startswith('!') %}
+! tmux send-keys -t "{{name}}" "{{prompt}}" C-m
+{% else %}
+! tmux send-keys -t "{{name}}" -l "{{prompt}}"
+! tmux send-keys -t "{{name}}" C-m C-m
+{% endif %}
+```
+```bash
+# Confirm the session was created
+! tmux list-sessions | grep "{{name}}" && echo "Subagent '{{name}}' spawned successfully"
+```
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "name"
+  required = true
+  description = "Name for the tmux session"
+  [[subCommands.args]]
+  name = "prompt"
+  required = true
+  description = "Initial prompt for the subagent"
+  [[subCommands.args]]
+  name = "model"
+  required = false
+  description = "Model to use (optional)"
+  [[subCommands.args]]
+  name = "detached"
+  required = false
+  default = "true"
+  description = "Run in detached mode"
+
+# Send a message to an existing subagent
+[[subCommands]]
+name = "send"
+description = "Send a message or command to an existing subagent"
+prompt = """
+{% if help %}
+Usage: /subagent send [OPTIONS]
+
+Send a message or command to an existing Antigravity (agy) subagent.
+
+Options:
+  --name     Name of the target tmux session (required)
+  --message  Message to send to the subagent (required)
+  --enter    Send Enter key after message (optional, default: true)
+  --help     Show this help message
+
+Examples:
+  /subagent send --name=researcher --message="Focus on CVE-2024 entries"
+  /subagent send --name=coder --message="Add error handling to the script"
+  /subagent send --name=analyst --message="! ls -la /tmp"
+  /subagent send --name=monitor --message="/help"
+
+Use Cases:
+- Guide subagent research direction
+- Request specific analysis or output
+- Send follow-up questions
+- Control subagent behavior
+{% else %}
+Execute the following commands to send a message to the subagent:
+```bash
+# First check if the session exists
+! tmux has-session -t "{{name}}" 2>/dev/null && echo "Session '{{name}}' found" || echo "Session '{{name}}' not found"
+```
+```bash
+# Send the message (check if it's a command or regular text)
+{% if message.startswith('!') %}
+! tmux send-keys -t "{{name}}" "{{message}}" C-m
+{% else %}
+! tmux send-keys -t "{{name}}" -l "{{message}}"
+! tmux send-keys -t "{{name}}" C-m C-m
+{% endif %}
+```
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "name"
+  required = true
+  description = "Name of the target tmux session"
+  [[subCommands.args]]
+  name = "message"
+  required = true
+  description = "Message to send to the subagent"
+  [[subCommands.args]]
+  name = "enter"
+  required = false
+  default = "true"
+  description = "Send Enter key after message"
+
+# Get output from a subagent
+[[subCommands]]
+name = "get-output"
+description = "Retrieve output from a subagent's tmux session"
+prompt = """
+{% if help %}
+Usage: /subagent get-output [OPTIONS]
+
+Retrieve output from a subagent's tmux session.
+
+Options:
+  --name   Name of the target tmux session (required)
+  --lines  Number of lines to retrieve (optional, default: 50)
+  --all    Get all available output (optional, overrides --lines)
+  --help   Show this help message
+
+Examples:
+  /subagent get-output --name=researcher
+  /subagent get-output --name=coder --lines=100
+  /subagent get-output --name=analyst --all=true
+
+Use Cases:
+- Check subagent progress and results
+- Retrieve analysis output
+- Monitor subagent status
+- Collect generated content
+{% else %}
+Execute the following command to get output from the subagent:
+```bash
+! tmux capture-pane -t "{{name}}" -p{% if all == "true" %} -S -{% else %} -S -{{lines}}{% endif %}
+```
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "name"
+  required = true
+  description = "Name of the target tmux session"
+  [[subCommands.args]]
+  name = "lines"
+  required = false
+  default = "50"
+  description = "Number of lines to retrieve"
+  [[subCommands.args]]
+  name = "all"
+  required = false
+  default = "false"
+  description = "Get all available output"
+
+# List all active subagents
+[[subCommands]]
+name = "list"
+description = "List all active Antigravity (agy) subagents"
+prompt = """
+{% if help %}
+Usage: /subagent list [OPTIONS]
+
+List all active Antigravity (agy) subagents (tmux sessions).
+
+Options:
+  --format  Output format (simple/detailed, default: simple)
+  --help    Show this help message
+
+Examples:
+  /subagent list
+  /subagent list --format=detailed
+
+The output shows:
+- Session name
+- Creation time
+- Window count
+- Attached status
+- Current activity
+
+Use Cases:
+- Monitor active subagents
+- Check subagent status
+- Manage multiple agents
+- Clean up old sessions
+{% else %}
+Execute the following command to list all tmux sessions:
+```bash
+! tmux list-sessions{% if format == "detailed" %} -F "Session: #{session_name} | Created: #{session_created_string} | Windows: #{session_windows} | Attached: #{session_attached}"{% endif %} 2>/dev/null || echo "No active subagents"
+```
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "format"
+  required = false
+  default = "simple"
+  description = "Output format (simple or detailed)"
+
+# Kill a subagent
+[[subCommands]]
+name = "kill"
+description = "Terminate an Antigravity (agy) subagent session"
+prompt = """
+{% if help %}
+Usage: /subagent kill [OPTIONS]
+
+Terminate an Antigravity (agy) subagent session.
+
+Options:
+  --name   Name of the tmux session to kill (required)
+  --force  Force kill without confirmation (optional, default: false)
+  --help   Show this help message
+
+Examples:
+  /subagent kill --name=researcher
+  /subagent kill --name=coder --force=true
+
+Warning:
+- This will immediately terminate the subagent
+- Any unsaved work will be lost
+- The session cannot be recovered
+
+Use Cases:
+- Clean up completed tasks
+- Stop runaway agents
+- Free up system resources
+- Reset stuck sessions
+{% else %}
+Execute the following command to kill the subagent:
+{% if force != "true" %}
+First, check if the session exists:
+```bash
+! tmux has-session -t "{{name}}" 2>/dev/null && echo "Session '{{name}}' exists and will be killed" || echo "Session '{{name}}' not found"
+```
+Then kill it:
+{% endif %}
+```bash
+! tmux kill-session -t "{{name}}" 2>/dev/null && echo "Subagent '{{name}}' terminated" || echo "Failed to kill session '{{name}}'"
+```
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "name"
+  required = true
+  description = "Name of the tmux session to kill"
+  [[subCommands.args]]
+  name = "force"
+  required = false
+  default = "false"
+  description = "Force kill without confirmation"
+
+# Attach to a subagent session
+[[subCommands]]
+name = "attach"
+description = "Attach to a subagent session for interactive viewing"
+prompt = """
+{% if help %}
+Usage: /subagent attach [OPTIONS]
+
+Attach to a subagent session for interactive viewing.
+
+Options:
+  --name      Name of the tmux session to attach (required)
+  --readonly  Attach in read-only mode (optional, default: false)
+  --help      Show this help message
+
+Examples:
+  /subagent attach --name=researcher
+  /subagent attach --name=coder --readonly=true
+
+Note:
+- Use Ctrl+B then D to detach from the session
+- The subagent continues running after detaching
+- Be careful not to interfere with agent operations
+
+Use Cases:
+- Monitor agent progress in real-time
+- Debug agent behavior
+- Manually intervene if needed
+- Observe agent interactions
+{% else %}
+Provide instructions for attaching to the session:
+```
+To attach to the '{{name}}' session, run this command in your terminal:
+tmux attach-session -t "{{name}}"{% if readonly == "true" %} -r{% endif %}
+
+To detach later, press: Ctrl+B, then D
+```
+Check if session exists:
+```bash
+! tmux has-session -t "{{name}}" 2>/dev/null && echo "Session '{{name}}' is ready to attach" || echo "Session '{{name}}' not found"
+```
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "name"
+  required = true
+  description = "Name of the tmux session to attach"
+  [[subCommands.args]]
+  name = "readonly"
+  required = false
+  default = "false"
+  description = "Attach in read-only mode"
+
+# Spawn in split pane (advanced)
+[[subCommands]]
+name = "spawn-split"
+description = "Start a new subagent in a split pane of current window"
+prompt = """
+{% if help %}
+Usage: /subagent spawn-split [OPTIONS]
+
+Start a new Antigravity (agy) subagent in a split pane instead of a new session.
+
+Options:
+  --name      Identifier for the pane (required)
+  --prompt    Initial prompt for the subagent (required)
+  --vertical  Split vertically instead of horizontally (optional)
+  --size      Percentage size of new pane (optional, default: 50)
+  --help      Show this help message
+
+Examples:
+  /subagent spawn-split --name=helper --prompt="Assist with coding"
+  /subagent spawn-split --name=monitor --prompt="Watch for errors" --vertical=true
+  /subagent spawn-split --name=tester --prompt="Run tests" --size=30
+
+Use Cases:
+- Quick helper agents in same window
+- Side-by-side comparison
+- Monitoring while working
+- Collaborative agents
+{% else %}
+Execute the following command to spawn subagent in split pane:
+```bash
+! tmux split-window {% if vertical == "true" %}-h{% else %}-v{% endif %}{% if size %} -p {{size}}{% endif %} "agy -p '{{prompt}}'"
+```
+Then tag the pane:
+```bash
+! tmux select-pane -T "{{name}}"
+```
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "name"
+  required = true
+  description = "Identifier for the pane"
+  [[subCommands.args]]
+  name = "prompt"
+  required = true
+  description = "Initial prompt for the subagent"
+  [[subCommands.args]]
+  name = "vertical"
+  required = false
+  default = "false"
+  description = "Split vertically instead of horizontally"
+  [[subCommands.args]]
+  name = "size"
+  required = false
+  default = "50"
+  description = "Percentage size of new pane"
+
+# Broadcast to multiple subagents
+[[subCommands]]
+name = "broadcast"
+description = "Send the same message to multiple subagents"
+prompt = """
+{% if help %}
+Usage: /subagent broadcast [OPTIONS]
+
+Send the same message to multiple subagents simultaneously.
+
+Options:
+  --names    Comma-separated list of session names (required)
+  --message  Message to broadcast (required)
+  --help     Show this help message
+
+Examples:
+  /subagent broadcast --names="researcher,analyst" --message="Focus on security issues"
+  /subagent broadcast --names="agent1,agent2,agent3" --message="/status"
+
+Use Cases:
+- Coordinate multiple agents
+- Synchronize agent activities
+- Send global commands
+- Update all agents at once
+{% else %}
+Broadcasting message to multiple subagents:
+{% set name_list = names.split(',') %}
+{% for session_name in name_list %}
+Send to {{session_name}}:
+```bash
+{% if message.startswith('!') %}
+! tmux send-keys -t "{{session_name|trim}}" "{{message}}" C-m 2>/dev/null && echo "Sent command to {{session_name|trim}}" || echo "Failed to send to {{session_name|trim}}"
+{% else %}
+! tmux send-keys -t "{{session_name|trim}}" -l "{{message}}" 2>/dev/null && tmux send-keys -t "{{session_name|trim}}" C-m C-m 2>/dev/null && echo "Sent to {{session_name|trim}}" || echo "Failed to send to {{session_name|trim}}"
+{% endif %}
+```
+{% endfor %}
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "names"
+  required = true
+  description = "Comma-separated list of session names"
+  [[subCommands.args]]
+  name = "message"
+  required = true
+  description = "Message to broadcast"
+
+# Check status of a subagent
+[[subCommands]]
+name = "status"
+description = "Check the status and recent activity of a subagent"
+prompt = """
+{% if help %}
+Usage: /subagent status [OPTIONS]
+
+Check the status and recent activity of a subagent.
+
+Options:
+  --name   Name of the tmux session to check (required)
+  --help   Show this help message
+
+Examples:
+  /subagent status --name=researcher
+  /subagent status --name=coder
+
+The output shows:
+- Session existence and basic info
+- Current pane content
+- Process running in the session
+- Recent output (last few lines)
+
+Use Cases:
+- Debug unresponsive agents
+- Check if agent is running properly
+- See current state without full output
+- Verify message delivery
+{% else %}
+Execute the following commands to check subagent status:
+```bash
+# Check if session exists
+! tmux has-session -t "{{name}}" 2>/dev/null && echo "✓ Session '{{name}}' exists" || echo "✗ Session '{{name}}' not found"
+```
+```bash
+# Show session info
+! tmux list-sessions -F "#{session_name}: #{session_windows} windows, created #{session_created_string}" | grep "{{name}}"
+```
+```bash
+# Show current process in the session
+! tmux list-panes -t "{{name}}" -F "Pane: #{pane_current_command} (PID: #{pane_pid})" 2>/dev/null
+```
+```bash
+# Show last few lines of output
+! tmux capture-pane -t "{{name}}" -p -S -10 2>/dev/null || echo "Cannot capture pane content"
+```
+{% endif %}
+"""
+  [[subCommands.args]]
+  name = "name"
+  required = true
+  description = "Name of the tmux session to check"
+
+# Help command
+[[subCommands]]
+name = "help"
+description = "Show available subagent commands and their descriptions"
+prompt = """
+ANTIGRAVITY (AGY) SUBAGENT MANAGEMENT SYSTEM
+
+Available Commands:
+
+BASIC OPERATIONS:
+  spawn         Start a new Antigravity (agy) subagent in a tmux session
+  send          Send a message to an existing subagent
+  get-output    Retrieve output from a subagent
+  list          List all active subagents
+  kill          Terminate a subagent session
+  attach        Attach to view subagent interactively
+
+ADVANCED OPERATIONS:
+  spawn-split   Start subagent in a split pane
+  broadcast     Send message to multiple subagents
+
+MESSAGE TYPES:
+- Regular prompts: Text without special prefix (uses double Enter)
+  Example: "Tell me about security"
+- Shell commands: Start with ! (single Enter, executed immediately)
+  Example: "! ls -la"
+- Slash commands: agy commands like /help, /model, etc.
+  Example: "/model opus"
+
+WORKFLOW EXAMPLES:
+
+1. Basic Research Agent:
+   /subagent spawn --name=research --prompt="Research AI safety"
+   /subagent send --name=research --message="Focus on alignment problems"
+   /subagent get-output --name=research
+   /subagent kill --name=research
+
+2. Parallel Analysis:
+   /subagent spawn --name=security --prompt="Analyze security logs"
+   /subagent spawn --name=performance --prompt="Analyze performance metrics"
+   /subagent broadcast --names="security,performance" --message="Generate summary report"
+
+3. Interactive Monitoring:
+   /subagent spawn --name=monitor --prompt="Monitor system status"
+   /subagent attach --name=monitor
+   (Press Ctrl+B, D to detach)
+
+TMUX KEY BINDINGS:
+  Ctrl+B, D     Detach from session
+  Ctrl+B, [     Enter scroll mode
+  Ctrl+B, ]     Paste buffer
+  Ctrl+B, ?     Show all key bindings
+
+For detailed help on any command:
+  /subagent COMMAND --help
+
+TIPS:
+- Subagents persist even if main agy exits
+- Use descriptive names for easy management
+- Check /subagent list regularly to manage sessions
+- Kill unused sessions to free resources
+"""

--- a/.gemini/skills/subagent/SKILL.md
+++ b/.gemini/skills/subagent/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: subagent
+description: Use when running, coordinating, monitoring, or managing parallel Antigravity (agy) subagent tasks in detached tmux sessions or split panes
+---
+
+# Antigravity (agy) Subagent Manager
+
+Orchestrates multiple parallel Antigravity (`agy`) CLI instances using `tmux` sessions. Subagents persist across exits, run background tasks or independent research, and can be queried or controlled asynchronously.
+
+## Quick Reference
+
+| Command | Action | Key Flags / Usage |
+| :--- | :--- | :--- |
+| `spawn` | Launch new subagent session | `--name=<name> --prompt="<prompt>" [--model=<model>]` |
+| `spawn-split` | Launch subagent in split pane | `--name=<name> --prompt="<prompt>" [--vertical=true] [--size=50]` |
+| `send` | Send prompt or command to subagent | `--name=<name> --message="<msg>"` |
+| `get-output` | Retrieve output from subagent | `--name=<name> [--lines=50] [--all=true]` |
+| `status` | Check session health, PID, and output | `--name=<name>` |
+| `list` | List active subagent sessions | `[--format=detailed]` |
+| `broadcast` | Send message to multiple subagents | `--names="agent1,agent2" --message="<msg>"` |
+| `attach` | View interactive session | `tmux attach-session -t <name>` |
+| `kill` | Terminate subagent session | `--name=<name>` |
+
+---
+
+## Subcommand Workflows
+
+### 1. `spawn`
+Starts a detached tmux session running `bash`, launches `agy`, waits for initialization, and submits the initial prompt.
+
+```bash
+# 1. Create detached tmux session
+tmux new-session -d -s "<name>" bash
+
+# 2. Launch agy in session
+tmux send-keys -t "<name>" "agy" C-m
+
+# 3. Wait for agy startup sequence (banner, tips, model connection)
+sleep 5
+
+# 4. Submit prompt (agy submits on single Enter)
+tmux send-keys -t "<name>" -l "<prompt>"
+tmux send-keys -t "<name>" C-m
+
+# 5. Confirm session is alive
+tmux list-sessions | grep "<name>"
+```
+
+*(If `--model` is specified, launch `agy --model <model>`)*
+
+### 2. `spawn-split`
+Spawns a subagent inside a split pane in the current tmux window using non-interactive print mode (`agy -p`).
+
+```bash
+# Horizontal (default) or Vertical (-h) split
+tmux split-window -v -p 50 "agy -p '<prompt>'"
+
+# Tag pane for identification
+tmux select-pane -T "<name>"
+```
+
+### 3. `send`
+Sends a prompt, shell command, or slash command to a running subagent session.
+
+```bash
+# For shell commands starting with '!':
+tmux send-keys -t "<name>" "<command>" C-m
+
+# For regular text prompts or slash commands:
+tmux send-keys -t "<name>" -l "<message>"
+tmux send-keys -t "<name>" C-m
+```
+
+### 4. `get-output`
+Captures text lines from the target session's scrollback buffer.
+
+```bash
+# Last N lines (default 50):
+tmux capture-pane -t "<name>" -p -S -50
+
+# Entire available buffer:
+tmux capture-pane -t "<name>" -p -S -
+```
+
+### 5. `status`
+Inspects session existence, pane PID, running command, and recent output snippet.
+
+```bash
+# Verify session exists
+tmux has-session -t "<name>" 2>/dev/null && echo "✓ Session '<name>' exists" || echo "✗ Session '<name>' not found"
+
+# Show session details
+tmux list-sessions -F "#{session_name}: #{session_windows} windows, created #{session_created_string}" | grep "<name>"
+
+# Show running process & PID
+tmux list-panes -t "<name>" -F "Pane: #{pane_current_command} (PID: #{pane_pid})" 2>/dev/null
+
+# Capture last 10 lines
+tmux capture-pane -t "<name>" -p -S -10 2>/dev/null
+```
+
+### 6. `list`
+Lists active tmux sessions.
+
+```bash
+# Simple
+tmux list-sessions 2>/dev/null || echo "No active subagents"
+
+# Detailed
+tmux list-sessions -F "Session: #{session_name} | Created: #{session_created_string} | Windows: #{session_windows} | Attached: #{session_attached}" 2>/dev/null
+```
+
+### 7. `broadcast`
+Iterates over a comma-separated list of session names and sends the message to each.
+
+```bash
+for session in $(echo "<names>" | tr "," "\n"); do
+  tmux send-keys -t "$session" -l "<message>" 2>/dev/null && tmux send-keys -t "$session" C-m 2>/dev/null && echo "Sent to $session" || echo "Failed to send to $session"
+done
+```
+
+### 8. `attach`
+Attach to view and interact with the session directly in your terminal:
+
+```bash
+tmux attach-session -t "<name>"
+```
+> **Detach Shortcut**: Press `Ctrl+B`, then `D` to detach and return to your parent terminal.
+
+### 9. `kill`
+Terminates the specified tmux session.
+
+```bash
+tmux kill-session -t "<name>" && echo "Subagent '<name>' terminated"
+```
+
+---
+
+## Tips & Operational Notes
+- Subagents run as persistent processes; always terminate unused sessions with `kill` to release system resources.
+- In Antigravity CLI (`agy`), a single Enter (`C-m`) submits prompts. Do not send double Enter (`C-m C-m`).
+- Use `-l` with `tmux send-keys` when sending prompt text to prevent tmux from interpreting special characters or key bindings.


### PR DESCRIPTION
## Description

Implements a comprehensive tmux-based subagent orchestration system for Antigravity CLI (`agy`), superseding and refactoring #146.

Provides both:
1. **Native Antigravity Skill** (`.agents/skills/subagent/SKILL.md` & `.gemini/skills/subagent/SKILL.md`): Discovered natively by `agy` as the `/subagent` slash command with full autocompletion and execution runbooks.
2. **Legacy TOML Command** (`.gemini/commands/subagent.toml`): Refactored to invoke `agy` for Gemini CLI backwards compatibility.

### Key Features
- **`spawn`**: Create new `agy` subagents in detached tmux sessions with configurable models and initial prompts
- **`send`**: Send messages to running subagents with intelligent handling for:
  - Regular text prompts (literal text with single Enter submission)
  - Shell commands (prefixed with `!`, single Enter execution)
  - Slash commands (`/help`, `/model`, etc.)
- **`get-output`**: Retrieve subagent output with configurable line limits or full history
- **`list`**: View all active subagent sessions in simple or detailed format
- **`kill`**: Cleanly terminate subagent sessions
- **`attach`**: Provides instructions for interactive session attachment
- **`status`**: Debug and monitor subagent health and activity
- **`spawn-split`**: Create subagents in split panes for side-by-side operation (`agy -p '...'`)
- **`broadcast`**: Send messages to multiple subagents simultaneously

### Technical Implementation
- Uses tmux sessions to maintain persistent `agy` instances that survive main process exits
- Starts bash shell first, then launches `agy` to ensure session stability
- Implements 5-second initialization delay to accommodate `agy` startup sequence
- Uses single Enter (`C-m`) matching `agy` interactive input submission
- Uses `tmux send-keys` with `-l` flag for literal text to prevent unintended shell interpretation

Closes #146